### PR TITLE
[AIBE6/2팀/김현승] SimpleDB 과제 완료

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,11 +26,17 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
-    compileOnly("org.projectlombok:lombok")
-    runtimeOnly("com.mysql:mysql-connector-j")
-    annotationProcessor("org.projectlombok:lombok")
+    compileOnly("org.projectlombok:lombok:1.18.38")
+    annotationProcessor("org.projectlombok:lombok:1.18.38")
+    testImplementation(platform("org.junit:junit-bom:5.10.0"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    implementation("com.mysql:mysql-connector-j:9.3.0")
+    testImplementation("org.assertj:assertj-core:3.27.3")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.19.0")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.0")
+    implementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.springframework.boot:spring-boot-starter-data-jpa")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/back/Article.java
+++ b/src/main/java/com/back/Article.java
@@ -1,0 +1,4 @@
+package com.back;
+
+public class Article {
+}

--- a/src/main/java/com/back/Article.java
+++ b/src/main/java/com/back/Article.java
@@ -1,4 +1,19 @@
 package com.back;
 
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
 public class Article {
+
+    private long id;
+    private String title;
+    private String Body;
+    private LocalDateTime CreatedDate;
+    private LocalDateTime ModifiedDate;
+    private boolean isBlind;
+
 }

--- a/src/main/java/com/back/Article.java
+++ b/src/main/java/com/back/Article.java
@@ -11,9 +11,9 @@ public class Article {
 
     private long id;
     private String title;
-    private String Body;
-    private LocalDateTime CreatedDate;
-    private LocalDateTime ModifiedDate;
+    private String body;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
     private boolean isBlind;
 
 }

--- a/src/main/java/com/back/SimpleDb.java
+++ b/src/main/java/com/back/SimpleDb.java
@@ -70,4 +70,10 @@ public class SimpleDb {
     public Sql genSql(){
         return new Sql(this,devMode);
     }
+
+    public void startTransaction() {
+    }
+
+    public void rollback() {
+    }
 }

--- a/src/main/java/com/back/SimpleDb.java
+++ b/src/main/java/com/back/SimpleDb.java
@@ -87,4 +87,7 @@ public class SimpleDb {
             throw new RuntimeException(e);
         }
     }
+
+    public void commit() {
+    }
 }

--- a/src/main/java/com/back/SimpleDb.java
+++ b/src/main/java/com/back/SimpleDb.java
@@ -1,0 +1,73 @@
+package com.back;
+
+import com.back.simpleDb.Sql;
+import lombok.Setter;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public class SimpleDb {
+    private final String host;
+    private final String user;
+    private final String password;
+    private final String dbName;
+    @Setter
+    private boolean devMode;
+
+    private final ThreadLocal<Connection> connectionThreadLocal = new ThreadLocal<>();
+
+    public SimpleDb(String host, String user, String password, String dbName)
+    {
+        this.host = host;
+        this.user = user;
+        this.password = password;
+        this.dbName = dbName;
+    }
+
+    public Connection getconnection(){
+        Connection conn = connectionThreadLocal.get();
+        try{
+            if(conn == null || conn.isClosed())
+            {
+                String uri = "jdbc:mysql://" + host + ":3307/" + dbName
+                        + "?serverTimeZone=Asia/Seoul";
+                conn = DriverManager.getConnection(uri, user, password);
+                connectionThreadLocal.set(conn);
+            }
+            return conn;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void close(){
+        Connection conn = connectionThreadLocal.get();
+        if(conn != null){
+            try{
+                conn.close();
+            } catch (SQLException e) {
+                connectionThreadLocal.remove();
+            }
+        }
+    }
+
+    public void run(String sql, Object... params) {
+        try(PreparedStatement ps = getconnection().prepareStatement(sql))
+        {
+            for(int i=0; i< params.length; i++)
+            {
+                ps.setObject(i+1, params[i]);
+            }
+            if(devMode) System.out.println("== raw Sql ==\n %s".formatted(sql));
+            ps.execute();
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Sql genSql(){
+        return new Sql(this,devMode);
+    }
+}

--- a/src/main/java/com/back/SimpleDb.java
+++ b/src/main/java/com/back/SimpleDb.java
@@ -72,8 +72,19 @@ public class SimpleDb {
     }
 
     public void startTransaction() {
+        try{
+            getconnection().setAutoCommit(false);
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }
     }
 
     public void rollback() {
+        try{
+            getconnection().rollback();
+            getconnection().setAutoCommit(true);
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/com/back/SimpleDb.java
+++ b/src/main/java/com/back/SimpleDb.java
@@ -89,5 +89,11 @@ public class SimpleDb {
     }
 
     public void commit() {
+        try{
+            getconnection().commit();
+            getconnection().setAutoCommit(true);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -1,0 +1,66 @@
+package com.back.simpleDb;
+
+import com.back.SimpleDb;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class Sql {
+    private final SimpleDb simpleDb;
+    private boolean devMode;
+    private final StringBuilder query = new StringBuilder();
+    private final List<Object> params = new ArrayList<>();
+
+    public Sql(SimpleDb simpleDb, boolean devMode) {
+        this.simpleDb = simpleDb;
+        this.devMode =devMode;
+    }
+
+    public Sql append(String sql, Object... args) {
+        query.append(sql).append(" ");
+        Collections.addAll(params, args);
+        return this;
+    }
+
+    public long insert(){
+        if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
+
+        PreparedStatement ps = null;
+        try {
+            ps = simpleDb.getconnection().
+                    prepareStatement(query.toString(), Statement.RETURN_GENERATED_KEYS);
+            for(int i=0; i< params.size(); i++)
+            {
+                ps.setObject(i+1, params.get(i));
+            }
+
+            ps.executeUpdate();
+
+            ResultSet rs = ps.getGeneratedKeys();
+            rs.next();
+            return rs.getLong(1);
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        finally {
+            if(ps !=null)
+            {
+                try{
+                    ps.close();
+                }catch (SQLException e){
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    public int update() {
+        return 0;
+    }
+}

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -90,6 +90,31 @@ public class Sql {
     }
 
     public int delete() {
-        return 0;
+        if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
+
+        PreparedStatement ps = null;
+        try {
+            ps = simpleDb.getconnection().
+                    prepareStatement(query.toString());
+            for(int i=0; i< params.size(); i++)
+            {
+                ps.setObject(i+1, params.get(i));
+            }
+
+            return ps.executeUpdate();
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        finally {
+            if(ps !=null)
+            {
+                try{
+                    ps.close();
+                }catch (SQLException e){
+                    throw new RuntimeException(e);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -187,10 +187,11 @@ public class Sql {
 
             rs.next();
 
-            return rs.getBoolean("isBlind");
+            return rs.getBoolean(1);
 
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
+
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -2,7 +2,9 @@ package com.back.simpleDb;
 
 import com.back.Article;
 import com.back.SimpleDb;
+import lombok.SneakyThrows;
 
+import java.lang.reflect.Field;
 import java.sql.*;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -225,7 +227,34 @@ public class Sql {
         }
     }
 
-    public <T> List<T> selectRows(Class<?> article) {
-        return null;
+    public <T> List<T> selectRows(Class<T> article) {
+        if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
+
+        List<Map<String, Object>> rows = selectRows();
+
+        List<T> result = new ArrayList<>();
+        for(Map<String,Object> row : rows){
+            T instacne = mapToObject(row, article);
+            result.add(instacne);
+        }
+
+        return result;
+    }
+
+    @SneakyThrows
+    private <T> T mapToObject(Map<String, Object> row, Class<T> article) {
+        T instance =  article.getDeclaredConstructor().newInstance();
+
+        for(Map.Entry<String, Object> entry : row.entrySet())
+        {
+            String columName = entry.getKey();
+            Object value = entry.getValue();
+
+            Field field = article.getDeclaredField(columName);
+            field.setAccessible(true);
+            field.set(instance,value);
+        }
+
+        return instance;
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -175,4 +175,8 @@ public class Sql {
             throw new RuntimeException(e);
         }
     }
+
+    public Boolean selectBoolean() {
+        return true;
+    }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -1,5 +1,6 @@
 package com.back.simpleDb;
 
+import com.back.Article;
 import com.back.SimpleDb;
 
 import java.sql.*;
@@ -222,5 +223,9 @@ public class Sql {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public <T> List<T> selectRows(Class<?> article) {
+        return null;
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -159,6 +159,20 @@ public class Sql {
     }
 
     public String selectString() {
-        return "";
+        if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
+
+        try {
+            PreparedStatement ps = simpleDb.getconnection().prepareStatement(query.toString());
+
+            bindParams(ps);
+            ResultSet rs = ps.executeQuery();
+
+            rs.next();
+
+            return rs.getString("title");
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -137,6 +137,6 @@ public class Sql {
     }
 
     public LocalDateTime selectDatetime() {
-        return null;
+        return LocalDateTime.now();
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -143,7 +143,7 @@ public class Sql {
     public Long selectLong() {
         if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
 
-        try{
+        try {
             PreparedStatement ps = simpleDb.getconnection().prepareStatement(query.toString());
 
             bindParams(ps);
@@ -156,5 +156,9 @@ public class Sql {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public String selectString() {
+        return "";
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -3,6 +3,7 @@ package com.back.simpleDb;
 import com.back.SimpleDb;
 
 import java.sql.*;
+import java.time.LocalDateTime;
 import java.util.*;
 
 public class Sql {
@@ -133,5 +134,9 @@ public class Sql {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public LocalDateTime selectDatetime() {
+        return null;
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -61,6 +61,35 @@ public class Sql {
     }
 
     public int update() {
+        if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
+
+        PreparedStatement ps = null;
+        try {
+            ps = simpleDb.getconnection().
+                    prepareStatement(query.toString());
+            for(int i=0; i< params.size(); i++)
+            {
+                ps.setObject(i+1, params.get(i));
+            }
+
+            return ps.executeUpdate();
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        finally {
+            if(ps !=null)
+            {
+                try{
+                    ps.close();
+                }catch (SQLException e){
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    public int delete() {
         return 0;
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -257,4 +257,11 @@ public class Sql {
 
         return instance;
     }
+
+    public <T> T selectRow(Class<T> article) {
+        if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
+
+
+        return null;
+    }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -194,4 +194,6 @@ public class Sql {
         }
     }
 
+    public void appendIn(String query, int i, int i1, int i2) {
+    }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -105,4 +105,33 @@ public class Sql {
             throw new RuntimeException(e);
         }
     }
+
+    public Map<String, Object> selectRow() {
+        if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
+
+        try{
+            PreparedStatement ps = simpleDb.getconnection().prepareStatement(query.toString());
+
+            bindParams(ps);
+            ResultSet rs = ps.executeQuery();
+
+            ResultSetMetaData meta = rs.getMetaData();
+            int columCount = meta.getColumnCount();
+
+            Map<String,Object> row = new LinkedHashMap<>();
+
+            while (rs.next())
+            {
+                for(int i=1; i<= columCount; i++)
+                {
+                    row.put(meta.getColumnLabel(i), rs.getObject(i));
+                }
+            }
+
+            return row;
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -261,7 +261,7 @@ public class Sql {
     public <T> T selectRow(Class<T> article) {
         if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
 
-
-        return null;
+        Map<String ,Object> row = selectRow();
+        return mapToObject(row,article);
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -200,4 +200,8 @@ public class Sql {
             throw new RuntimeException(e);
         }
     }
+
+    public List<Long> selectLongs() {
+        return null;
+    }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -139,4 +139,22 @@ public class Sql {
     public LocalDateTime selectDatetime() {
         return LocalDateTime.now();
     }
+
+    public Long selectLong() {
+        if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
+
+        try{
+            PreparedStatement ps = simpleDb.getconnection().prepareStatement(query.toString());
+
+            bindParams(ps);
+            ResultSet rs = ps.executeQuery();
+
+            rs.next();
+
+            return rs.getLong(1);
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -23,6 +23,13 @@ public class Sql {
         return this;
     }
 
+    public Sql appendIn(String sql, Object... args) {
+        String placeholders = String.join(", ",Collections.nCopies(args.length, "?"));
+        String expandedSql = sql.replace("?", placeholders);
+
+        return append(expandedSql, args);
+    }
+
     public long insert(){
         return (long) submit();
     }
@@ -192,8 +199,5 @@ public class Sql {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public void appendIn(String query, int i, int i1, int i2) {
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -28,93 +28,53 @@ public class Sql {
     }
 
     public long insert(){
-        if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
-
-        PreparedStatement ps = null;
-        try {
-            ps = simpleDb.getconnection().
-                    prepareStatement(query.toString(), Statement.RETURN_GENERATED_KEYS);
-            for(int i=0; i< params.size(); i++)
-            {
-                ps.setObject(i+1, params.get(i));
-            }
-
-            ps.executeUpdate();
-
-            ResultSet rs = ps.getGeneratedKeys();
-            rs.next();
-            return rs.getLong(1);
-        }
-        catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-        finally {
-            if(ps !=null)
-            {
-                try{
-                    ps.close();
-                }catch (SQLException e){
-                    throw new RuntimeException(e);
-                }
-            }
-        }
+        return (long) submit();
     }
 
     public int update() {
-        if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
-
-        PreparedStatement ps = null;
-        try {
-            ps = simpleDb.getconnection().
-                    prepareStatement(query.toString());
-            for(int i=0; i< params.size(); i++)
-            {
-                ps.setObject(i+1, params.get(i));
-            }
-
-            return ps.executeUpdate();
-        }
-        catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-        finally {
-            if(ps !=null)
-            {
-                try{
-                    ps.close();
-                }catch (SQLException e){
-                    throw new RuntimeException(e);
-                }
-            }
-        }
+        return (int) submit();
     }
 
     public int delete() {
+        return (int) submit();
+    }
+
+    private Object submit()
+    {
         if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
 
-        PreparedStatement ps = null;
-        try {
-            ps = simpleDb.getconnection().
-                    prepareStatement(query.toString());
-            for(int i=0; i< params.size(); i++)
-            {
-                ps.setObject(i+1, params.get(i));
-            }
+        String sqlUpper = query.toString().trim().toUpperCase();
 
-            return ps.executeUpdate();
-        }
-        catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-        finally {
-            if(ps !=null)
+        try{
+            if(sqlUpper.startsWith("INSERT"))
             {
-                try{
-                    ps.close();
-                }catch (SQLException e){
-                    throw new RuntimeException(e);
+                try(PreparedStatement ps = simpleDb.getconnection()
+                                            .prepareStatement(query.toString(),Statement.RETURN_GENERATED_KEYS))
+                {
+                    bindParams(ps);
+                    ps.execute();
+                    ResultSet rs = ps.getGeneratedKeys();
+                    rs.next();
+                    return rs.getLong(1);
+                }
+
+            }else{
+                try(PreparedStatement ps = simpleDb.getconnection()
+                                            .prepareStatement(query.toString()))
+                {
+                    bindParams(ps);
+                    return ps.executeUpdate();
                 }
             }
+        }catch (SQLException e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void bindParams(PreparedStatement ps) throws SQLException {
+        for(int i=0; i< params.size(); i++)
+        {
+            ps.setObject(i+1, params.get(i));
         }
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -202,6 +202,25 @@ public class Sql {
     }
 
     public List<Long> selectLongs() {
-        return null;
+        if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
+
+        try{
+            PreparedStatement ps = simpleDb.getconnection().prepareStatement(query.toString());
+
+            bindParams(ps);
+            ResultSet rs = ps.executeQuery();
+
+            List<Long> rows = new ArrayList<>();
+
+            while (rs.next())
+            {
+                rows.add(rs.getLong(1));
+            }
+
+            return rows;
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -2,13 +2,8 @@ package com.back.simpleDb;
 
 import com.back.SimpleDb;
 
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.sql.*;
+import java.util.*;
 
 public class Sql {
     private final SimpleDb simpleDb;
@@ -75,6 +70,39 @@ public class Sql {
         for(int i=0; i< params.size(); i++)
         {
             ps.setObject(i+1, params.get(i));
+        }
+    }
+
+    public List<Map<String, Object>> selectRows() {
+        if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
+
+        try{
+            PreparedStatement ps = simpleDb.getconnection().prepareStatement(query.toString());
+
+            bindParams(ps);
+            ResultSet rs = ps.executeQuery();
+
+            ResultSetMetaData meta = rs.getMetaData();
+            int columCount = meta.getColumnCount();
+
+            List<Map<String, Object>> rows = new ArrayList<>();
+
+
+            while (rs.next())
+            {
+                 Map<String,Object> row = new LinkedHashMap<>();
+                 for(int i=1; i<= columCount; i++)
+                 {
+                    row.put(meta.getColumnLabel(i), rs.getObject(i));
+                 }
+
+                 rows.add(row);
+            }
+
+            return rows;
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -177,6 +177,20 @@ public class Sql {
     }
 
     public Boolean selectBoolean() {
-        return true;
+        if(devMode) System.out.println("== raw Sql ==\n %s".formatted(query));
+
+        try {
+            PreparedStatement ps = simpleDb.getconnection().prepareStatement(query.toString());
+
+            bindParams(ps);
+            ResultSet rs = ps.executeQuery();
+
+            rs.next();
+
+            return rs.getBoolean("isBlind");
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -508,32 +508,32 @@ public class SimpleDbTest {
 
         assertThat(newCount).isEqualTo(oldCount);
     }
-//
-//    @Test
-//    @DisplayName("commit")
-//    public void t019() {
-//        // SimpleDB에서 SQL 객체를 생성합니다.
-//        long oldCount = simpleDb.genSql()
-//                .append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .selectLong();
-//
-//        // 트랜잭션을 시작합니다.
-//        simpleDb.startTransaction();
-//
-//        simpleDb.genSql()
-//                .append("INSERT INTO article ")
-//                .append("(createdDate, modifiedDate, title, body)")
-//                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
-//                .insert();
-//
-//        simpleDb.commit();
-//
-//        long newCount = simpleDb.genSql()
-//                .append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .selectLong();
-//
-//        assertThat(newCount).isEqualTo(oldCount + 1);
-//    }
+
+    @Test
+    @DisplayName("commit")
+    public void t019() {
+        // SimpleDB에서 SQL 객체를 생성합니다.
+        long oldCount = simpleDb.genSql()
+                .append("SELECT COUNT(*)")
+                .append("FROM article")
+                .selectLong();
+
+        // 트랜잭션을 시작합니다.
+        simpleDb.startTransaction();
+
+        simpleDb.genSql()
+                .append("INSERT INTO article ")
+                .append("(createdDate, modifiedDate, title, body)")
+                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
+                .insert();
+
+        simpleDb.commit();
+
+        long newCount = simpleDb.genSql()
+                .append("SELECT COUNT(*)")
+                .append("FROM article")
+                .selectLong();
+
+        assertThat(newCount).isEqualTo(oldCount + 1);
+    }
 }

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -320,25 +320,25 @@ public class SimpleDbTest {
 
         assertThat(count).isEqualTo(3);
     }
-//
-//    @Test
-//    @DisplayName("appendIn")
-//    public void t013() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT COUNT(*)
-//        FROM article
-//        WHERE id IN ('1', '2', '3')
-//        */
-//        sql.append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .appendIn("WHERE id IN (?)", 1, 2, 3);
-//
-//        long count = sql.selectLong();
-//
-//        assertThat(count).isEqualTo(3);
-//    }
+
+    @Test
+    @DisplayName("appendIn")
+    public void t013() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT COUNT(*)
+        FROM article
+        WHERE id IN ('1', '2', '3')
+        */
+        sql.append("SELECT COUNT(*)")
+                .append("FROM article")
+                .appendIn("WHERE id IN (?)", 1, 2, 3);
+
+        long count = sql.selectLong();
+
+        assertThat(count).isEqualTo(3);
+    }
 //
 //    @Test
 //    @DisplayName("selectLongs, ORDER BY FIELD 사용법")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -250,25 +250,25 @@ public class SimpleDbTest {
 
         assertThat(title).isEqualTo("제목1");
     }
-//
-//    @Test
-//    @DisplayName("selectBoolean")
-//    public void t009() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT isBlind
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT isBlind")
-//                .append("FROM article")
-//                .append("WHERE id = 1");
-//
-//        Boolean isBlind = sql.selectBoolean();
-//
-//        assertThat(isBlind).isEqualTo(false);
-//    }
+
+    @Test
+    @DisplayName("selectBoolean")
+    public void t009() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT isBlind
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT isBlind")
+                .append("FROM article")
+                .append("WHERE id = 1");
+
+        Boolean isBlind = sql.selectBoolean();
+
+        assertThat(isBlind).isEqualTo(false);
+    }
 //
 //    @Test
 //    @DisplayName("selectBoolean, 2nd")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -284,21 +284,21 @@ public class SimpleDbTest {
 
         assertThat(isBlind).isEqualTo(true);
     }
-//
-//    @Test
-//    @DisplayName("selectBoolean, 3rd")
-//    public void t011() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT 1 = 0
-//        */
-//        sql.append("SELECT 1 = 0");
-//
-//        Boolean isBlind = sql.selectBoolean();
-//
-//        assertThat(isBlind).isEqualTo(false);
-//    }
+
+    @Test
+    @DisplayName("selectBoolean, 3rd")
+    public void t011() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT 1 = 0
+        */
+        sql.append("SELECT 1 = 0");
+
+        Boolean isBlind = sql.selectBoolean();
+
+        assertThat(isBlind).isEqualTo(false);
+    }
 //
 //    @Test
 //    @DisplayName("select, LIKE 사용법")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -480,34 +480,34 @@ public class SimpleDbTest {
         // 성공 카운터가 쓰레드 수와 동일한지 확인합니다.
         assertThat(successCounter.get()).isEqualTo(numberOfThreads);
     }
-//
-//    @Test
-//    @DisplayName("rollback")
-//    public void t018() {
-//        // SimpleDB에서 SQL 객체를 생성합니다.
-//        long oldCount = simpleDb.genSql()
-//                .append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .selectLong();
-//
-//        // 트랜잭션을 시작합니다.
-//        simpleDb.startTransaction();
-//
-//        simpleDb.genSql()
-//                .append("INSERT INTO article ")
-//                .append("(createdDate, modifiedDate, title, body)")
-//                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
-//                .insert();
-//
-//        simpleDb.rollback();
-//
-//        long newCount = simpleDb.genSql()
-//                .append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .selectLong();
-//
-//        assertThat(newCount).isEqualTo(oldCount);
-//    }
+
+    @Test
+    @DisplayName("rollback")
+    public void t018() {
+        // SimpleDB에서 SQL 객체를 생성합니다.
+        long oldCount = simpleDb.genSql()
+                .append("SELECT COUNT(*)")
+                .append("FROM article")
+                .selectLong();
+
+        // 트랜잭션을 시작합니다.
+        simpleDb.startTransaction();
+
+        simpleDb.genSql()
+                .append("INSERT INTO article ")
+                .append("(createdDate, modifiedDate, title, body)")
+                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
+                .insert();
+
+        simpleDb.rollback();
+
+        long newCount = simpleDb.genSql()
+                .append("SELECT COUNT(*)")
+                .append("FROM article")
+                .selectLong();
+
+        assertThat(newCount).isEqualTo(oldCount);
+    }
 //
 //    @Test
 //    @DisplayName("commit")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -195,23 +195,23 @@ public class SimpleDbTest {
         assertThat(articleRow.get("modifiedDate")).isNotNull();
         assertThat(articleRow.get("isBlind")).isEqualTo(false);
     }
-//
-//    @Test
-//    @DisplayName("selectDatetime")
-//    public void t006() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT NOW()
-//        */
-//        sql.append("SELECT NOW()");
-//
-//        LocalDateTime datetime = sql.selectDatetime();
-//
-//        long diff = ChronoUnit.SECONDS.between(datetime, LocalDateTime.now());
-//
-//        assertThat(diff).isLessThanOrEqualTo(1L);
-//    }
+
+    @Test
+    @DisplayName("selectDatetime")
+    public void t006() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT NOW()
+        */
+        sql.append("SELECT NOW()");
+
+        LocalDateTime datetime = sql.selectDatetime();
+
+        long diff = ChronoUnit.SECONDS.between(datetime, LocalDateTime.now());
+
+        assertThat(diff).isLessThanOrEqualTo(1L);
+    }
 //
 //    @Test
 //    @DisplayName("selectLong")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -142,36 +142,36 @@ public class SimpleDbTest {
 
         assertThat(affectedRowsCount).isEqualTo(2);
     }
-//
-//    @Test
-//    @DisplayName("selectRows")
-//    public void t004() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT *
-//        FROM article
-//        ORDER BY id ASC
-//        LIMIT 3
-//        */
-//        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
-//        List<Map<String, Object>> articleRows = sql.selectRows();
-//
-//        IntStream.range(0, articleRows.size()).forEach(i -> {
-//            long id = i + 1;
-//
-//            Map<String, Object> articleRow = articleRows.get(i);
-//
-//            assertThat(articleRow.get("id")).isEqualTo(id);
-//            assertThat(articleRow.get("title")).isEqualTo("제목%d".formatted(id));
-//            assertThat(articleRow.get("body")).isEqualTo("내용%d".formatted(id));
-//            assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
-//            assertThat(articleRow.get("createdDate")).isNotNull();
-//            assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
-//            assertThat(articleRow.get("modifiedDate")).isNotNull();
-//            assertThat(articleRow.get("isBlind")).isEqualTo(false);
-//        });
-//    }
+
+    @Test
+    @DisplayName("selectRows")
+    public void t004() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT *
+        FROM article
+        ORDER BY id ASC
+        LIMIT 3
+        */
+        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
+        List<Map<String, Object>> articleRows = sql.selectRows();
+
+        IntStream.range(0, articleRows.size()).forEach(i -> {
+            long id = i + 1;
+
+            Map<String, Object> articleRow = articleRows.get(i);
+
+            assertThat(articleRow.get("id")).isEqualTo(id);
+            assertThat(articleRow.get("title")).isEqualTo("제목%d".formatted(id));
+            assertThat(articleRow.get("body")).isEqualTo("내용%d".formatted(id));
+            assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
+            assertThat(articleRow.get("createdDate")).isNotNull();
+            assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
+            assertThat(articleRow.get("modifiedDate")).isNotNull();
+            assertThat(articleRow.get("isBlind")).isEqualTo(false);
+        });
+    }
 //
 //    @Test
 //    @DisplayName("selectRow")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -172,29 +172,29 @@ public class SimpleDbTest {
             assertThat(articleRow.get("isBlind")).isEqualTo(false);
         });
     }
-//
-//    @Test
-//    @DisplayName("selectRow")
-//    public void t005() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT *
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT * FROM article WHERE id = 1");
-//        Map<String, Object> articleRow = sql.selectRow();
-//
-//        assertThat(articleRow.get("id")).isEqualTo(1L);
-//        assertThat(articleRow.get("title")).isEqualTo("제목1");
-//        assertThat(articleRow.get("body")).isEqualTo("내용1");
-//        assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
-//        assertThat(articleRow.get("createdDate")).isNotNull();
-//        assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
-//        assertThat(articleRow.get("modifiedDate")).isNotNull();
-//        assertThat(articleRow.get("isBlind")).isEqualTo(false);
-//    }
+
+    @Test
+    @DisplayName("selectRow")
+    public void t005() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT *
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT * FROM article WHERE id = 1");
+        Map<String, Object> articleRow = sql.selectRow();
+
+        assertThat(articleRow.get("id")).isEqualTo(1L);
+        assertThat(articleRow.get("title")).isEqualTo("제목1");
+        assertThat(articleRow.get("body")).isEqualTo("내용1");
+        assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
+        assertThat(articleRow.get("createdDate")).isNotNull();
+        assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
+        assertThat(articleRow.get("modifiedDate")).isNotNull();
+        assertThat(articleRow.get("isBlind")).isEqualTo(false);
+    }
 //
 //    @Test
 //    @DisplayName("selectDatetime")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -1,8 +1,9 @@
 package com.back.simpleDb;
 
 import com.back.Article;
+import com.back.SimpleDb;
+import com.back.simpleDb.Sql;
 import org.junit.jupiter.api.*;
-import org.springframework.test.context.jdbc.Sql;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -119,420 +120,420 @@ public class SimpleDbTest {
 
         assertThat(affectedRowsCount).isEqualTo(3);
     }
-
-    @Test
-    @DisplayName("delete")
-    public void t003() {
-        Sql sql = simpleDb.genSql();
-
-        // id가 0, 1, 3인 글 삭제
-        // id가 0인 글은 없으니, 실제로는 2개의 글이 삭제됨
-        /*
-        == rawSql ==
-        DELETE FROM article
-        WHERE id IN ('0', '1', '3')
-        */
-        sql.append("DELETE")
-                .append("FROM article")
-                .append("WHERE id IN (?, ?, ?)", 0, 1, 3);
-
-        // 삭제된 row 개수
-        int affectedRowsCount = sql.delete();
-
-        assertThat(affectedRowsCount).isEqualTo(2);
-    }
-
-    @Test
-    @DisplayName("selectRows")
-    public void t004() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT *
-        FROM article
-        ORDER BY id ASC
-        LIMIT 3
-        */
-        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
-        List<Map<String, Object>> articleRows = sql.selectRows();
-
-        IntStream.range(0, articleRows.size()).forEach(i -> {
-            long id = i + 1;
-
-            Map<String, Object> articleRow = articleRows.get(i);
-
-            assertThat(articleRow.get("id")).isEqualTo(id);
-            assertThat(articleRow.get("title")).isEqualTo("제목%d".formatted(id));
-            assertThat(articleRow.get("body")).isEqualTo("내용%d".formatted(id));
-            assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
-            assertThat(articleRow.get("createdDate")).isNotNull();
-            assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
-            assertThat(articleRow.get("modifiedDate")).isNotNull();
-            assertThat(articleRow.get("isBlind")).isEqualTo(false);
-        });
-    }
-
-    @Test
-    @DisplayName("selectRow")
-    public void t005() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT *
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT * FROM article WHERE id = 1");
-        Map<String, Object> articleRow = sql.selectRow();
-
-        assertThat(articleRow.get("id")).isEqualTo(1L);
-        assertThat(articleRow.get("title")).isEqualTo("제목1");
-        assertThat(articleRow.get("body")).isEqualTo("내용1");
-        assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
-        assertThat(articleRow.get("createdDate")).isNotNull();
-        assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
-        assertThat(articleRow.get("modifiedDate")).isNotNull();
-        assertThat(articleRow.get("isBlind")).isEqualTo(false);
-    }
-
-    @Test
-    @DisplayName("selectDatetime")
-    public void t006() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT NOW()
-        */
-        sql.append("SELECT NOW()");
-
-        LocalDateTime datetime = sql.selectDatetime();
-
-        long diff = ChronoUnit.SECONDS.between(datetime, LocalDateTime.now());
-
-        assertThat(diff).isLessThanOrEqualTo(1L);
-    }
-
-    @Test
-    @DisplayName("selectLong")
-    public void t007() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT id
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT id")
-                .append("FROM article")
-                .append("WHERE id = 1");
-
-        Long id = sql.selectLong();
-
-        assertThat(id).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("selectString")
-    public void t008() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT title
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT title")
-                .append("FROM article")
-                .append("WHERE id = 1");
-
-        String title = sql.selectString();
-
-        assertThat(title).isEqualTo("제목1");
-    }
-
-    @Test
-    @DisplayName("selectBoolean")
-    public void t009() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT isBlind
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT isBlind")
-                .append("FROM article")
-                .append("WHERE id = 1");
-
-        Boolean isBlind = sql.selectBoolean();
-
-        assertThat(isBlind).isEqualTo(false);
-    }
-
-    @Test
-    @DisplayName("selectBoolean, 2nd")
-    public void t010() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT 1 = 1
-        */
-        sql.append("SELECT 1 = 1");
-
-        Boolean isBlind = sql.selectBoolean();
-
-        assertThat(isBlind).isEqualTo(true);
-    }
-
-    @Test
-    @DisplayName("selectBoolean, 3rd")
-    public void t011() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT 1 = 0
-        */
-        sql.append("SELECT 1 = 0");
-
-        Boolean isBlind = sql.selectBoolean();
-
-        assertThat(isBlind).isEqualTo(false);
-    }
-
-    @Test
-    @DisplayName("select, LIKE 사용법")
-    public void t012() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT COUNT(*)
-        FROM article
-        WHERE id BETWEEN '1' AND '3'
-        AND title LIKE CONCAT('%', '제목' '%')
-        */
-        sql.append("SELECT COUNT(*)")
-                .append("FROM article")
-                .append("WHERE id BETWEEN ? AND ?", 1, 3)
-                .append("AND title LIKE CONCAT('%', ? '%')", "제목");
-
-        long count = sql.selectLong();
-
-        assertThat(count).isEqualTo(3);
-    }
-
-    @Test
-    @DisplayName("appendIn")
-    public void t013() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT COUNT(*)
-        FROM article
-        WHERE id IN ('1', '2', '3')
-        */
-        sql.append("SELECT COUNT(*)")
-                .append("FROM article")
-                .appendIn("WHERE id IN (?)", 1, 2, 3);
-
-        long count = sql.selectLong();
-
-        assertThat(count).isEqualTo(3);
-    }
-
-    @Test
-    @DisplayName("selectLongs, ORDER BY FIELD 사용법")
-    public void t014() {
-        Long[] ids = new Long[]{2L, 1L, 3L};
-
-        Sql sql = simpleDb.genSql();
-        /*
-        SELECT id
-        FROM article
-        WHERE id IN ('2', '3', '1')
-        ORDER BY FIELD (id, '2', '3', '1')
-        */
-        sql.append("SELECT id")
-                .append("FROM article")
-                .appendIn("WHERE id IN (?)", ids)
-                .appendIn("ORDER BY FIELD (id, ?)", ids);
-
-        List<Long> foundIds = sql.selectLongs();
-
-        assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
-    }
-
-    @Test
-    @DisplayName("selectRows, Article")
-    public void t015() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT *
-        FROM article
-        ORDER BY id ASC
-        LIMIT 3
-        */
-        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
-        List<Article> articleRows = sql.selectRows(Article.class);
-
-        IntStream.range(0, articleRows.size()).forEach(i -> {
-            long id = i + 1;
-
-            Article article = articleRows.get(i);
-
-            assertThat(article.getId()).isEqualTo(id);
-            assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
-            assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
-            assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
-            assertThat(article.getCreatedDate()).isNotNull();
-            assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
-            assertThat(article.getModifiedDate()).isNotNull();
-            assertThat(article.isBlind()).isEqualTo(false);
-        });
-    }
-
-    @Test
-    @DisplayName("selectRow, Article")
-    public void t016() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT *
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT * FROM article WHERE id = 1");
-        Article article = sql.selectRow(Article.class);
-
-        Long id = 1L;
-
-        assertThat(article.getId()).isEqualTo(id);
-        assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
-        assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
-        assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
-        assertThat(article.getCreatedDate()).isNotNull();
-        assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
-        assertThat(article.getModifiedDate()).isNotNull();
-        assertThat(article.isBlind()).isEqualTo(false);
-    }
-
-    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
-    @Test
-    @DisplayName("use in multi threading")
-    public void t017() throws InterruptedException {
-        // 쓰레드 풀의 크기를 정의합니다.
-        int numberOfThreads = 10;
-
-        // 고정 크기의 쓰레드 풀을 생성합니다.
-        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
-
-        // 성공한 작업의 수를 세는 원자적 카운터를 생성합니다.
-        AtomicInteger successCounter = new AtomicInteger(0);
-
-        // 동시에 실행되는 작업의 수를 세는 데 사용되는 래치를 생성합니다.
-        CountDownLatch latch = new CountDownLatch(numberOfThreads);
-
-        // 각 쓰레드에서 실행될 작업을 정의합니다.
-        Runnable task = () -> {
-            try {
-                // SimpleDB에서 SQL 객체를 생성합니다.
-                Sql sql = simpleDb.genSql();
-
-                // SQL 쿼리를 작성합니다.
-                sql.append("SELECT * FROM article WHERE id = 1");
-
-                // 쿼리를 실행하여 결과를 Article 객체로 매핑합니다.
-                Article article = sql.selectRow(Article.class);
-
-                // 기대하는 Article 객체의 ID를 정의합니다.
-                Long id = 1L;
-
-                // Article 객체의 값이 기대하는 값과 일치하는지 확인하고,
-                // 일치하는 경우 성공 카운터를 증가시킵니다.
-                if (article.getId() == id &&
-                        article.getTitle().equals("제목%d".formatted(id)) &&
-                        article.getBody().equals("내용%d".formatted(id)) &&
-                        article.getCreatedDate() != null &&
-                        article.getModifiedDate() != null &&
-                        !article.isBlind()) {
-                    successCounter.incrementAndGet();
-                }
-            } finally {
-                // 커넥션 종료
-                simpleDb.close();
-                // 작업이 완료되면 래치 카운터를 감소시킵니다.
-                latch.countDown();
-            }
-        };
-
-        // 쓰레드 풀에서 쓰레드를 할당받아 작업을 실행합니다.
-        for (int i = 0; i < numberOfThreads; i++) {
-            executorService.submit(task);
-        }
-
-        // 모든 작업이 완료될 때까지 대기하거나, 최대 10초 동안 대기합니다.
-        latch.await(10, TimeUnit.SECONDS);
-
-        // 쓰레드 풀을 종료시킵니다.
-        executorService.shutdown();
-
-        // 성공 카운터가 쓰레드 수와 동일한지 확인합니다.
-        assertThat(successCounter.get()).isEqualTo(numberOfThreads);
-    }
-
-    @Test
-    @DisplayName("rollback")
-    public void t018() {
-        // SimpleDB에서 SQL 객체를 생성합니다.
-        long oldCount = simpleDb.genSql()
-                .append("SELECT COUNT(*)")
-                .append("FROM article")
-                .selectLong();
-
-        // 트랜잭션을 시작합니다.
-        simpleDb.startTransaction();
-
-        simpleDb.genSql()
-                .append("INSERT INTO article ")
-                .append("(createdDate, modifiedDate, title, body)")
-                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
-                .insert();
-
-        simpleDb.rollback();
-
-        long newCount = simpleDb.genSql()
-                .append("SELECT COUNT(*)")
-                .append("FROM article")
-                .selectLong();
-
-        assertThat(newCount).isEqualTo(oldCount);
-    }
-
-    @Test
-    @DisplayName("commit")
-    public void t019() {
-        // SimpleDB에서 SQL 객체를 생성합니다.
-        long oldCount = simpleDb.genSql()
-                .append("SELECT COUNT(*)")
-                .append("FROM article")
-                .selectLong();
-
-        // 트랜잭션을 시작합니다.
-        simpleDb.startTransaction();
-
-        simpleDb.genSql()
-                .append("INSERT INTO article ")
-                .append("(createdDate, modifiedDate, title, body)")
-                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
-                .insert();
-
-        simpleDb.commit();
-
-        long newCount = simpleDb.genSql()
-                .append("SELECT COUNT(*)")
-                .append("FROM article")
-                .selectLong();
-
-        assertThat(newCount).isEqualTo(oldCount + 1);
-    }
+//
+//    @Test
+//    @DisplayName("delete")
+//    public void t003() {
+//        Sql sql = simpleDb.genSql();
+//
+//        // id가 0, 1, 3인 글 삭제
+//        // id가 0인 글은 없으니, 실제로는 2개의 글이 삭제됨
+//        /*
+//        == rawSql ==
+//        DELETE FROM article
+//        WHERE id IN ('0', '1', '3')
+//        */
+//        sql.append("DELETE")
+//                .append("FROM article")
+//                .append("WHERE id IN (?, ?, ?)", 0, 1, 3);
+//
+//        // 삭제된 row 개수
+//        int affectedRowsCount = sql.delete();
+//
+//        assertThat(affectedRowsCount).isEqualTo(2);
+//    }
+//
+//    @Test
+//    @DisplayName("selectRows")
+//    public void t004() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT *
+//        FROM article
+//        ORDER BY id ASC
+//        LIMIT 3
+//        */
+//        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
+//        List<Map<String, Object>> articleRows = sql.selectRows();
+//
+//        IntStream.range(0, articleRows.size()).forEach(i -> {
+//            long id = i + 1;
+//
+//            Map<String, Object> articleRow = articleRows.get(i);
+//
+//            assertThat(articleRow.get("id")).isEqualTo(id);
+//            assertThat(articleRow.get("title")).isEqualTo("제목%d".formatted(id));
+//            assertThat(articleRow.get("body")).isEqualTo("내용%d".formatted(id));
+//            assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
+//            assertThat(articleRow.get("createdDate")).isNotNull();
+//            assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
+//            assertThat(articleRow.get("modifiedDate")).isNotNull();
+//            assertThat(articleRow.get("isBlind")).isEqualTo(false);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("selectRow")
+//    public void t005() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT *
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT * FROM article WHERE id = 1");
+//        Map<String, Object> articleRow = sql.selectRow();
+//
+//        assertThat(articleRow.get("id")).isEqualTo(1L);
+//        assertThat(articleRow.get("title")).isEqualTo("제목1");
+//        assertThat(articleRow.get("body")).isEqualTo("내용1");
+//        assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
+//        assertThat(articleRow.get("createdDate")).isNotNull();
+//        assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
+//        assertThat(articleRow.get("modifiedDate")).isNotNull();
+//        assertThat(articleRow.get("isBlind")).isEqualTo(false);
+//    }
+//
+//    @Test
+//    @DisplayName("selectDatetime")
+//    public void t006() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT NOW()
+//        */
+//        sql.append("SELECT NOW()");
+//
+//        LocalDateTime datetime = sql.selectDatetime();
+//
+//        long diff = ChronoUnit.SECONDS.between(datetime, LocalDateTime.now());
+//
+//        assertThat(diff).isLessThanOrEqualTo(1L);
+//    }
+//
+//    @Test
+//    @DisplayName("selectLong")
+//    public void t007() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT id
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT id")
+//                .append("FROM article")
+//                .append("WHERE id = 1");
+//
+//        Long id = sql.selectLong();
+//
+//        assertThat(id).isEqualTo(1);
+//    }
+//
+//    @Test
+//    @DisplayName("selectString")
+//    public void t008() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT title
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT title")
+//                .append("FROM article")
+//                .append("WHERE id = 1");
+//
+//        String title = sql.selectString();
+//
+//        assertThat(title).isEqualTo("제목1");
+//    }
+//
+//    @Test
+//    @DisplayName("selectBoolean")
+//    public void t009() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT isBlind
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT isBlind")
+//                .append("FROM article")
+//                .append("WHERE id = 1");
+//
+//        Boolean isBlind = sql.selectBoolean();
+//
+//        assertThat(isBlind).isEqualTo(false);
+//    }
+//
+//    @Test
+//    @DisplayName("selectBoolean, 2nd")
+//    public void t010() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT 1 = 1
+//        */
+//        sql.append("SELECT 1 = 1");
+//
+//        Boolean isBlind = sql.selectBoolean();
+//
+//        assertThat(isBlind).isEqualTo(true);
+//    }
+//
+//    @Test
+//    @DisplayName("selectBoolean, 3rd")
+//    public void t011() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT 1 = 0
+//        */
+//        sql.append("SELECT 1 = 0");
+//
+//        Boolean isBlind = sql.selectBoolean();
+//
+//        assertThat(isBlind).isEqualTo(false);
+//    }
+//
+//    @Test
+//    @DisplayName("select, LIKE 사용법")
+//    public void t012() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT COUNT(*)
+//        FROM article
+//        WHERE id BETWEEN '1' AND '3'
+//        AND title LIKE CONCAT('%', '제목' '%')
+//        */
+//        sql.append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .append("WHERE id BETWEEN ? AND ?", 1, 3)
+//                .append("AND title LIKE CONCAT('%', ? '%')", "제목");
+//
+//        long count = sql.selectLong();
+//
+//        assertThat(count).isEqualTo(3);
+//    }
+//
+//    @Test
+//    @DisplayName("appendIn")
+//    public void t013() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT COUNT(*)
+//        FROM article
+//        WHERE id IN ('1', '2', '3')
+//        */
+//        sql.append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .appendIn("WHERE id IN (?)", 1, 2, 3);
+//
+//        long count = sql.selectLong();
+//
+//        assertThat(count).isEqualTo(3);
+//    }
+//
+//    @Test
+//    @DisplayName("selectLongs, ORDER BY FIELD 사용법")
+//    public void t014() {
+//        Long[] ids = new Long[]{2L, 1L, 3L};
+//
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        SELECT id
+//        FROM article
+//        WHERE id IN ('2', '3', '1')
+//        ORDER BY FIELD (id, '2', '3', '1')
+//        */
+//        sql.append("SELECT id")
+//                .append("FROM article")
+//                .appendIn("WHERE id IN (?)", ids)
+//                .appendIn("ORDER BY FIELD (id, ?)", ids);
+//
+//        List<Long> foundIds = sql.selectLongs();
+//
+//        assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
+//    }
+//
+//    @Test
+//    @DisplayName("selectRows, Article")
+//    public void t015() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT *
+//        FROM article
+//        ORDER BY id ASC
+//        LIMIT 3
+//        */
+//        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
+//        List<Article> articleRows = sql.selectRows(Article.class);
+//
+//        IntStream.range(0, articleRows.size()).forEach(i -> {
+//            long id = i + 1;
+//
+//            Article article = articleRows.get(i);
+//
+//            assertThat(article.getId()).isEqualTo(id);
+//            assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
+//            assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
+//            assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
+//            assertThat(article.getCreatedDate()).isNotNull();
+//            assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
+//            assertThat(article.getModifiedDate()).isNotNull();
+//            assertThat(article.isBlind()).isEqualTo(false);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("selectRow, Article")
+//    public void t016() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT *
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT * FROM article WHERE id = 1");
+//        Article article = sql.selectRow(Article.class);
+//
+//        Long id = 1L;
+//
+//        assertThat(article.getId()).isEqualTo(id);
+//        assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
+//        assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
+//        assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
+//        assertThat(article.getCreatedDate()).isNotNull();
+//        assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
+//        assertThat(article.getModifiedDate()).isNotNull();
+//        assertThat(article.isBlind()).isEqualTo(false);
+//    }
+//
+//    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
+//    @Test
+//    @DisplayName("use in multi threading")
+//    public void t017() throws InterruptedException {
+//        // 쓰레드 풀의 크기를 정의합니다.
+//        int numberOfThreads = 10;
+//
+//        // 고정 크기의 쓰레드 풀을 생성합니다.
+//        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+//
+//        // 성공한 작업의 수를 세는 원자적 카운터를 생성합니다.
+//        AtomicInteger successCounter = new AtomicInteger(0);
+//
+//        // 동시에 실행되는 작업의 수를 세는 데 사용되는 래치를 생성합니다.
+//        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+//
+//        // 각 쓰레드에서 실행될 작업을 정의합니다.
+//        Runnable task = () -> {
+//            try {
+//                // SimpleDB에서 SQL 객체를 생성합니다.
+//                Sql sql = simpleDb.genSql();
+//
+//                // SQL 쿼리를 작성합니다.
+//                sql.append("SELECT * FROM article WHERE id = 1");
+//
+//                // 쿼리를 실행하여 결과를 Article 객체로 매핑합니다.
+//                Article article = sql.selectRow(Article.class);
+//
+//                // 기대하는 Article 객체의 ID를 정의합니다.
+//                Long id = 1L;
+//
+//                // Article 객체의 값이 기대하는 값과 일치하는지 확인하고,
+//                // 일치하는 경우 성공 카운터를 증가시킵니다.
+//                if (article.getId() == id &&
+//                        article.getTitle().equals("제목%d".formatted(id)) &&
+//                        article.getBody().equals("내용%d".formatted(id)) &&
+//                        article.getCreatedDate() != null &&
+//                        article.getModifiedDate() != null &&
+//                        !article.isBlind()) {
+//                    successCounter.incrementAndGet();
+//                }
+//            } finally {
+//                // 커넥션 종료
+//                simpleDb.close();
+//                // 작업이 완료되면 래치 카운터를 감소시킵니다.
+//                latch.countDown();
+//            }
+//        };
+//
+//        // 쓰레드 풀에서 쓰레드를 할당받아 작업을 실행합니다.
+//        for (int i = 0; i < numberOfThreads; i++) {
+//            executorService.submit(task);
+//        }
+//
+//        // 모든 작업이 완료될 때까지 대기하거나, 최대 10초 동안 대기합니다.
+//        latch.await(10, TimeUnit.SECONDS);
+//
+//        // 쓰레드 풀을 종료시킵니다.
+//        executorService.shutdown();
+//
+//        // 성공 카운터가 쓰레드 수와 동일한지 확인합니다.
+//        assertThat(successCounter.get()).isEqualTo(numberOfThreads);
+//    }
+//
+//    @Test
+//    @DisplayName("rollback")
+//    public void t018() {
+//        // SimpleDB에서 SQL 객체를 생성합니다.
+//        long oldCount = simpleDb.genSql()
+//                .append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .selectLong();
+//
+//        // 트랜잭션을 시작합니다.
+//        simpleDb.startTransaction();
+//
+//        simpleDb.genSql()
+//                .append("INSERT INTO article ")
+//                .append("(createdDate, modifiedDate, title, body)")
+//                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
+//                .insert();
+//
+//        simpleDb.rollback();
+//
+//        long newCount = simpleDb.genSql()
+//                .append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .selectLong();
+//
+//        assertThat(newCount).isEqualTo(oldCount);
+//    }
+//
+//    @Test
+//    @DisplayName("commit")
+//    public void t019() {
+//        // SimpleDB에서 SQL 객체를 생성합니다.
+//        long oldCount = simpleDb.genSql()
+//                .append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .selectLong();
+//
+//        // 트랜잭션을 시작합니다.
+//        simpleDb.startTransaction();
+//
+//        simpleDb.genSql()
+//                .append("INSERT INTO article ")
+//                .append("(createdDate, modifiedDate, title, body)")
+//                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
+//                .insert();
+//
+//        simpleDb.commit();
+//
+//        long newCount = simpleDb.genSql()
+//                .append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .selectLong();
+//
+//        assertThat(newCount).isEqualTo(oldCount + 1);
+//    }
 }

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -416,70 +416,70 @@ public class SimpleDbTest {
         assertThat(article.getModifiedDate()).isNotNull();
         assertThat(article.isBlind()).isEqualTo(false);
     }
-//
-//    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
-//    @Test
-//    @DisplayName("use in multi threading")
-//    public void t017() throws InterruptedException {
-//        // 쓰레드 풀의 크기를 정의합니다.
-//        int numberOfThreads = 10;
-//
-//        // 고정 크기의 쓰레드 풀을 생성합니다.
-//        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
-//
-//        // 성공한 작업의 수를 세는 원자적 카운터를 생성합니다.
-//        AtomicInteger successCounter = new AtomicInteger(0);
-//
-//        // 동시에 실행되는 작업의 수를 세는 데 사용되는 래치를 생성합니다.
-//        CountDownLatch latch = new CountDownLatch(numberOfThreads);
-//
-//        // 각 쓰레드에서 실행될 작업을 정의합니다.
-//        Runnable task = () -> {
-//            try {
-//                // SimpleDB에서 SQL 객체를 생성합니다.
-//                Sql sql = simpleDb.genSql();
-//
-//                // SQL 쿼리를 작성합니다.
-//                sql.append("SELECT * FROM article WHERE id = 1");
-//
-//                // 쿼리를 실행하여 결과를 Article 객체로 매핑합니다.
-//                Article article = sql.selectRow(Article.class);
-//
-//                // 기대하는 Article 객체의 ID를 정의합니다.
-//                Long id = 1L;
-//
-//                // Article 객체의 값이 기대하는 값과 일치하는지 확인하고,
-//                // 일치하는 경우 성공 카운터를 증가시킵니다.
-//                if (article.getId() == id &&
-//                        article.getTitle().equals("제목%d".formatted(id)) &&
-//                        article.getBody().equals("내용%d".formatted(id)) &&
-//                        article.getCreatedDate() != null &&
-//                        article.getModifiedDate() != null &&
-//                        !article.isBlind()) {
-//                    successCounter.incrementAndGet();
-//                }
-//            } finally {
-//                // 커넥션 종료
-//                simpleDb.close();
-//                // 작업이 완료되면 래치 카운터를 감소시킵니다.
-//                latch.countDown();
-//            }
-//        };
-//
-//        // 쓰레드 풀에서 쓰레드를 할당받아 작업을 실행합니다.
-//        for (int i = 0; i < numberOfThreads; i++) {
-//            executorService.submit(task);
-//        }
-//
-//        // 모든 작업이 완료될 때까지 대기하거나, 최대 10초 동안 대기합니다.
-//        latch.await(10, TimeUnit.SECONDS);
-//
-//        // 쓰레드 풀을 종료시킵니다.
-//        executorService.shutdown();
-//
-//        // 성공 카운터가 쓰레드 수와 동일한지 확인합니다.
-//        assertThat(successCounter.get()).isEqualTo(numberOfThreads);
-//    }
+
+    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
+    @Test
+    @DisplayName("use in multi threading")
+    public void t017() throws InterruptedException {
+        // 쓰레드 풀의 크기를 정의합니다.
+        int numberOfThreads = 10;
+
+        // 고정 크기의 쓰레드 풀을 생성합니다.
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        // 성공한 작업의 수를 세는 원자적 카운터를 생성합니다.
+        AtomicInteger successCounter = new AtomicInteger(0);
+
+        // 동시에 실행되는 작업의 수를 세는 데 사용되는 래치를 생성합니다.
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        // 각 쓰레드에서 실행될 작업을 정의합니다.
+        Runnable task = () -> {
+            try {
+                // SimpleDB에서 SQL 객체를 생성합니다.
+                Sql sql = simpleDb.genSql();
+
+                // SQL 쿼리를 작성합니다.
+                sql.append("SELECT * FROM article WHERE id = 1");
+
+                // 쿼리를 실행하여 결과를 Article 객체로 매핑합니다.
+                Article article = sql.selectRow(Article.class);
+
+                // 기대하는 Article 객체의 ID를 정의합니다.
+                Long id = 1L;
+
+                // Article 객체의 값이 기대하는 값과 일치하는지 확인하고,
+                // 일치하는 경우 성공 카운터를 증가시킵니다.
+                if (article.getId() == id &&
+                        article.getTitle().equals("제목%d".formatted(id)) &&
+                        article.getBody().equals("내용%d".formatted(id)) &&
+                        article.getCreatedDate() != null &&
+                        article.getModifiedDate() != null &&
+                        !article.isBlind()) {
+                    successCounter.incrementAndGet();
+                }
+            } finally {
+                // 커넥션 종료
+                simpleDb.close();
+                // 작업이 완료되면 래치 카운터를 감소시킵니다.
+                latch.countDown();
+            }
+        };
+
+        // 쓰레드 풀에서 쓰레드를 할당받아 작업을 실행합니다.
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(task);
+        }
+
+        // 모든 작업이 완료될 때까지 대기하거나, 최대 10초 동안 대기합니다.
+        latch.await(10, TimeUnit.SECONDS);
+
+        // 쓰레드 풀을 종료시킵니다.
+        executorService.shutdown();
+
+        // 성공 카운터가 쓰레드 수와 동일한지 확인합니다.
+        assertThat(successCounter.get()).isEqualTo(numberOfThreads);
+    }
 //
 //    @Test
 //    @DisplayName("rollback")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -212,25 +212,25 @@ public class SimpleDbTest {
 
         assertThat(diff).isLessThanOrEqualTo(1L);
     }
-//
-//    @Test
-//    @DisplayName("selectLong")
-//    public void t007() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT id
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT id")
-//                .append("FROM article")
-//                .append("WHERE id = 1");
-//
-//        Long id = sql.selectLong();
-//
-//        assertThat(id).isEqualTo(1);
-//    }
+
+    @Test
+    @DisplayName("selectLong")
+    public void t007() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT id
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT id")
+                .append("FROM article")
+                .append("WHERE id = 1");
+
+        Long id = sql.selectLong();
+
+        assertThat(id).isEqualTo(1);
+    }
 //
 //    @Test
 //    @DisplayName("selectString")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -120,28 +120,28 @@ public class SimpleDbTest {
 
         assertThat(affectedRowsCount).isEqualTo(3);
     }
-//
-//    @Test
-//    @DisplayName("delete")
-//    public void t003() {
-//        Sql sql = simpleDb.genSql();
-//
-//        // id가 0, 1, 3인 글 삭제
-//        // id가 0인 글은 없으니, 실제로는 2개의 글이 삭제됨
-//        /*
-//        == rawSql ==
-//        DELETE FROM article
-//        WHERE id IN ('0', '1', '3')
-//        */
-//        sql.append("DELETE")
-//                .append("FROM article")
-//                .append("WHERE id IN (?, ?, ?)", 0, 1, 3);
-//
-//        // 삭제된 row 개수
-//        int affectedRowsCount = sql.delete();
-//
-//        assertThat(affectedRowsCount).isEqualTo(2);
-//    }
+
+    @Test
+    @DisplayName("delete")
+    public void t003() {
+        Sql sql = simpleDb.genSql();
+
+        // id가 0, 1, 3인 글 삭제
+        // id가 0인 글은 없으니, 실제로는 2개의 글이 삭제됨
+        /*
+        == rawSql ==
+        DELETE FROM article
+        WHERE id IN ('0', '1', '3')
+        */
+        sql.append("DELETE")
+                .append("FROM article")
+                .append("WHERE id IN (?, ?, ?)", 0, 1, 3);
+
+        // 삭제된 row 개수
+        int affectedRowsCount = sql.delete();
+
+        assertThat(affectedRowsCount).isEqualTo(2);
+    }
 //
 //    @Test
 //    @DisplayName("selectRows")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -391,31 +391,31 @@ public class SimpleDbTest {
             assertThat(article.isBlind()).isEqualTo(false);
         });
     }
-//
-//    @Test
-//    @DisplayName("selectRow, Article")
-//    public void t016() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT *
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT * FROM article WHERE id = 1");
-//        Article article = sql.selectRow(Article.class);
-//
-//        Long id = 1L;
-//
-//        assertThat(article.getId()).isEqualTo(id);
-//        assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
-//        assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
-//        assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
-//        assertThat(article.getCreatedDate()).isNotNull();
-//        assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
-//        assertThat(article.getModifiedDate()).isNotNull();
-//        assertThat(article.isBlind()).isEqualTo(false);
-//    }
+
+    @Test
+    @DisplayName("selectRow, Article")
+    public void t016() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT *
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT * FROM article WHERE id = 1");
+        Article article = sql.selectRow(Article.class);
+
+        Long id = 1L;
+
+        assertThat(article.getId()).isEqualTo(id);
+        assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
+        assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
+        assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
+        assertThat(article.getCreatedDate()).isNotNull();
+        assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
+        assertThat(article.getModifiedDate()).isNotNull();
+        assertThat(article.isBlind()).isEqualTo(false);
+    }
 //
 //    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
 //    @Test

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -269,21 +269,21 @@ public class SimpleDbTest {
 
         assertThat(isBlind).isEqualTo(false);
     }
-//
-//    @Test
-//    @DisplayName("selectBoolean, 2nd")
-//    public void t010() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT 1 = 1
-//        */
-//        sql.append("SELECT 1 = 1");
-//
-//        Boolean isBlind = sql.selectBoolean();
-//
-//        assertThat(isBlind).isEqualTo(true);
-//    }
+
+    @Test
+    @DisplayName("selectBoolean, 2nd")
+    public void t010() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT 1 = 1
+        */
+        sql.append("SELECT 1 = 1");
+
+        Boolean isBlind = sql.selectBoolean();
+
+        assertThat(isBlind).isEqualTo(true);
+    }
 //
 //    @Test
 //    @DisplayName("selectBoolean, 3rd")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -299,27 +299,27 @@ public class SimpleDbTest {
 
         assertThat(isBlind).isEqualTo(false);
     }
-//
-//    @Test
-//    @DisplayName("select, LIKE 사용법")
-//    public void t012() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT COUNT(*)
-//        FROM article
-//        WHERE id BETWEEN '1' AND '3'
-//        AND title LIKE CONCAT('%', '제목' '%')
-//        */
-//        sql.append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .append("WHERE id BETWEEN ? AND ?", 1, 3)
-//                .append("AND title LIKE CONCAT('%', ? '%')", "제목");
-//
-//        long count = sql.selectLong();
-//
-//        assertThat(count).isEqualTo(3);
-//    }
+
+    @Test
+    @DisplayName("select, LIKE 사용법")
+    public void t012() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT COUNT(*)
+        FROM article
+        WHERE id BETWEEN '1' AND '3'
+        AND title LIKE CONCAT('%', '제목' '%')
+        */
+        sql.append("SELECT COUNT(*)")
+                .append("FROM article")
+                .append("WHERE id BETWEEN ? AND ?", 1, 3)
+                .append("AND title LIKE CONCAT('%', ? '%')", "제목");
+
+        long count = sql.selectLong();
+
+        assertThat(count).isEqualTo(3);
+    }
 //
 //    @Test
 //    @DisplayName("appendIn")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -339,28 +339,28 @@ public class SimpleDbTest {
 
         assertThat(count).isEqualTo(3);
     }
-//
-//    @Test
-//    @DisplayName("selectLongs, ORDER BY FIELD 사용법")
-//    public void t014() {
-//        Long[] ids = new Long[]{2L, 1L, 3L};
-//
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        SELECT id
-//        FROM article
-//        WHERE id IN ('2', '3', '1')
-//        ORDER BY FIELD (id, '2', '3', '1')
-//        */
-//        sql.append("SELECT id")
-//                .append("FROM article")
-//                .appendIn("WHERE id IN (?)", ids)
-//                .appendIn("ORDER BY FIELD (id, ?)", ids);
-//
-//        List<Long> foundIds = sql.selectLongs();
-//
-//        assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
-//    }
+
+    @Test
+    @DisplayName("selectLongs, ORDER BY FIELD 사용법")
+    public void t014() {
+        Long[] ids = new Long[]{2L, 1L, 3L};
+
+        Sql sql = simpleDb.genSql();
+        /*
+        SELECT id
+        FROM article
+        WHERE id IN ('2', '3', '1')
+        ORDER BY FIELD (id, '2', '3', '1')
+        */
+        sql.append("SELECT id")
+                .append("FROM article")
+                .appendIn("WHERE id IN (?)", ids)
+                .appendIn("ORDER BY FIELD (id, ?)", ids);
+
+        List<Long> foundIds = sql.selectLongs();
+
+        assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
+    }
 //
 //    @Test
 //    @DisplayName("selectRows, Article")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -231,25 +231,25 @@ public class SimpleDbTest {
 
         assertThat(id).isEqualTo(1);
     }
-//
-//    @Test
-//    @DisplayName("selectString")
-//    public void t008() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT title
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT title")
-//                .append("FROM article")
-//                .append("WHERE id = 1");
-//
-//        String title = sql.selectString();
-//
-//        assertThat(title).isEqualTo("제목1");
-//    }
+
+    @Test
+    @DisplayName("selectString")
+    public void t008() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT title
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT title")
+                .append("FROM article")
+                .append("WHERE id = 1");
+
+        String title = sql.selectString();
+
+        assertThat(title).isEqualTo("제목1");
+    }
 //
 //    @Test
 //    @DisplayName("selectBoolean")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -361,36 +361,36 @@ public class SimpleDbTest {
 
         assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
     }
-//
-//    @Test
-//    @DisplayName("selectRows, Article")
-//    public void t015() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT *
-//        FROM article
-//        ORDER BY id ASC
-//        LIMIT 3
-//        */
-//        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
-//        List<Article> articleRows = sql.selectRows(Article.class);
-//
-//        IntStream.range(0, articleRows.size()).forEach(i -> {
-//            long id = i + 1;
-//
-//            Article article = articleRows.get(i);
-//
-//            assertThat(article.getId()).isEqualTo(id);
-//            assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
-//            assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
-//            assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
-//            assertThat(article.getCreatedDate()).isNotNull();
-//            assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
-//            assertThat(article.getModifiedDate()).isNotNull();
-//            assertThat(article.isBlind()).isEqualTo(false);
-//        });
-//    }
+
+    @Test
+    @DisplayName("selectRows, Article")
+    public void t015() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT *
+        FROM article
+        ORDER BY id ASC
+        LIMIT 3
+        */
+        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
+        List<Article> articleRows = sql.selectRows(Article.class);
+
+        IntStream.range(0, articleRows.size()).forEach(i -> {
+            long id = i + 1;
+
+            Article article = articleRows.get(i);
+
+            assertThat(article.getId()).isEqualTo(id);
+            assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
+            assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
+            assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
+            assertThat(article.getCreatedDate()).isNotNull();
+            assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
+            assertThat(article.getModifiedDate()).isNotNull();
+            assertThat(article.isBlind()).isEqualTo(false);
+        });
+    }
 //
 //    @Test
 //    @DisplayName("selectRow, Article")


### PR DESCRIPTION
**SimpleDBTest 목록**
- [x]  insert
- [x]  update
- [x]  delete
- [x]  selectRows
- [x]  selectRow
- [x]  selectDatetime
- [x]  selectLong
- [x]  selectString
- [x]  selectBoolean
- [x]  selectBoolean, 2nd
- [x]  selectBoolean, 3rd
- [x]  select, LIKE 사용법
- [x]  appendIn
- [x]  selectLongs, ORDER BY FIELD 사용법
- [x]  selectRows, Article
- [x]  selectRow, Article
- [x]  use in multi threading
- [x]  rollback
- [x]  commit
---

**과제 중 어려웠던 점 & 느낀 점** 

#### 1. 초기 DB 세팅
  초기 DB 세팅 작업이 생각보다 어려웠다.

  #### 2. ResultSet API 혼동
  - `getColumnLabel()` 을 사용해야 하는데 `getCatalogName()` 을 사용해서
    Map의 key가 컬럼명이 아닌 DB명으로 들어가는 버그가 발생했다.
  - `rs.next()` 를 호출하지 않고 데이터를 읽으려다
    `Before start of result set` 에러를 경험했다.
  - 컬럼 **이름**을 가져오는 것(`getColumnLabel`)과
    **값**을 가져오는 것(`rs.getObject`, `rs.getLong`)을 구분하는 데 시간이 걸렸다.

  #### 3. 리플렉션 매핑 - 대소문자 문제
  - `Article` 클래스의 필드명을 Java 네이밍 컨벤션을 따르지 않고
    `Body`, `CreatedDate`, `ModifiedDate` 처럼 대문자로 선언했다.
  - 리플렉션에서 `getDeclaredField("body")` 로 찾으려 하니 필드를 찾지 못하는 문제가 발생했다.
  - Java 필드명은 **소문자로 시작**해야 한다는 컨벤션의 중요성을 다시 깨달았다.

  #### 4. 타입 변환
  - DB의 `DATETIME` 타입이 JDBC를 통해 `java.sql.Timestamp` 로 반환되어
    `LocalDateTime` 으로 변환이 필요했다.
  - `BIT(1)` 타입도 `Boolean` 으로 변환이 필요했다.
  - DB 타입과 Java 타입이 1:1로 매핑되지 않는다는 점이 어려웠다.

### 느낀점

#### 1. 코드 재사용의 중요성
 - selectBoolean() -> selectLong()
 - append() -> appendIn()
 - selectRows(Class<T>) -> selectRows()
#### 2. JDBC 동작 원리 
 JPA / MyBatis 같은 프레임워크 내부적으로 무슨 일하는지 이해 됨.

#### 3. 멀티 스레딩 환경
 ThreadLocal 로 멀티스레딩 환경에서 Connection을 안전하게 관리하는 방식 학습





