### PR TITLE
[AIBE6/1팀/임현호] SimpleDb 과제 완료

### DIFF
--- a/src/main/java/com/back/domain/Article.java
+++ b/src/main/java/com/back/domain/Article.java
@@ -1,0 +1,18 @@
+package com.back.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class Article {
+    private long id;
+    private String title;
+    private String body;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+    private boolean isBlind;
+
+}

--- a/src/main/java/com/back/simpleDb/SimpleDb.java
+++ b/src/main/java/com/back/simpleDb/SimpleDb.java
@@ -62,9 +62,20 @@ public class SimpleDb {
     }
 
     public void startTransaction() {
+        try{
+            getConnection().setAutoCommit(false);
+        }catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void rollback() {
+        try{
+            getConnection().rollback();
+            getConnection().setAutoCommit(true);
+        }catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void commit() {

--- a/src/main/java/com/back/simpleDb/SimpleDb.java
+++ b/src/main/java/com/back/simpleDb/SimpleDb.java
@@ -88,5 +88,6 @@ public class SimpleDb {
     }
 
     public void close() {
+        //커넥션 닫기
     }
 }

--- a/src/main/java/com/back/simpleDb/SimpleDb.java
+++ b/src/main/java/com/back/simpleDb/SimpleDb.java
@@ -1,8 +1,17 @@
 package com.back.simpleDb;
 
+
 public class SimpleDb {
+    private final String host;
+    private final String user;
+    private final String password;
+    private final String database;
 
     public SimpleDb(String host, String username, String password, String database) {
+        this.host = host;
+        this.user = username;
+        this.password = password;
+        this.database = database;
     }
 
     public void setDevMode(boolean devMode) {

--- a/src/main/java/com/back/simpleDb/SimpleDb.java
+++ b/src/main/java/com/back/simpleDb/SimpleDb.java
@@ -79,6 +79,12 @@ public class SimpleDb {
     }
 
     public void commit() {
+        try{
+            getConnection().commit();
+            getConnection().setAutoCommit(true);
+        }catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void close() {

--- a/src/main/java/com/back/simpleDb/SimpleDb.java
+++ b/src/main/java/com/back/simpleDb/SimpleDb.java
@@ -27,7 +27,7 @@ public class SimpleDb {
         this.devMode = devMode;
     }
 
-    private Connection getConnection() {
+    Connection getConnection() {
         Connection conn = myConn.get();
         try {
             if (conn == null || conn.isClosed()) {
@@ -54,7 +54,7 @@ public class SimpleDb {
     }
 
     public Sql genSql() {
-        return new Sql();
+        return new Sql(this);
     }
 
     public void startTransaction() {

--- a/src/main/java/com/back/simpleDb/SimpleDb.java
+++ b/src/main/java/com/back/simpleDb/SimpleDb.java
@@ -1,8 +1,6 @@
 package com.back.simpleDb;
 
 
-import lombok.Getter;
-
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -34,6 +32,12 @@ public class SimpleDb {
                 conn = DriverManager.getConnection(
                         "jdbc:mysql://" + host + "/" + database, user, password
                 );
+
+                //SQL 실행 전에 타임존 설정
+                try (PreparedStatement ps = conn.prepareStatement("SET time_zone = '+09:00'")) {
+                    ps.execute();
+                }
+
                 myConn.set(conn);
             }
         } catch (SQLException e) {

--- a/src/main/java/com/back/simpleDb/SimpleDb.java
+++ b/src/main/java/com/back/simpleDb/SimpleDb.java
@@ -1,0 +1,29 @@
+package com.back.simpleDb;
+
+public class SimpleDb {
+
+    public SimpleDb(String host, String username, String password, String database) {
+    }
+
+    public void setDevMode(boolean devMode) {
+    }
+
+    public void run(String sql, Object... params) {
+    }
+
+    public Sql genSql() {
+        return new Sql();
+    }
+
+    public void startTransaction() {
+    }
+
+    public void rollback() {
+    }
+
+    public void commit() {
+    }
+
+    public void close() {
+    }
+}

--- a/src/main/java/com/back/simpleDb/SimpleDb.java
+++ b/src/main/java/com/back/simpleDb/SimpleDb.java
@@ -1,11 +1,20 @@
 package com.back.simpleDb;
 
 
+import lombok.Getter;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
 public class SimpleDb {
     private final String host;
     private final String user;
     private final String password;
     private final String database;
+    private boolean devMode;
+    private final ThreadLocal<Connection> myConn = new ThreadLocal<>();
 
     public SimpleDb(String host, String username, String password, String database) {
         this.host = host;
@@ -15,9 +24,33 @@ public class SimpleDb {
     }
 
     public void setDevMode(boolean devMode) {
+        this.devMode = devMode;
+    }
+
+    private Connection getConnection() {
+        Connection conn = myConn.get();
+        try {
+            if (conn == null || conn.isClosed()) {
+                conn = DriverManager.getConnection(
+                        "jdbc:mysql://" + host + "/" + database, user, password
+                );
+                myConn.set(conn);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return conn;
     }
 
     public void run(String sql, Object... params) {
+        try (PreparedStatement ps = getConnection().prepareStatement(sql)) {
+            for (int i = 0; i < params.length; i++) {
+                ps.setObject(i + 1, params[i]);
+            }
+            ps.execute();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public Sql genSql() {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -1,5 +1,7 @@
 package com.back.simpleDb;
 
+import com.back.domain.Article;
+
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -127,8 +129,26 @@ public class Sql {
         }
     }
 
+    /*DB결과를 Map 리스트로 만든다음
+    selectRows()로 가져온 결과를 List<Map<String, Object>>로 가져온다.*/
     public <T> List<T> selectRows(Class<T> clazz) {
-        return null;
+        List<Map<String, Object>> rows = selectRows();
+        List<Article> articles = new ArrayList<>();
+
+        for(int i = 0 ; i < rows.size(); i++) {
+            Map<String, Object> row = rows.get(i);
+            Article article = new Article();
+
+            article.setId((Long) row.get("id"));
+            article.setTitle((String) row.get("title"));
+            article.setBody((String) row.get("body"));
+            article.setCreatedDate((LocalDateTime) row.get("createdDate"));
+            article.setModifiedDate((LocalDateTime) row.get("modifiedDate"));
+            article.setBlind((Boolean) row.get("isBlind"));
+
+            articles.add(article);
+        }
+        return (List<T>) articles;
     }
 
     /*
@@ -201,6 +221,7 @@ public class Sql {
         그 값이 1인지 비교해서 true 또는 false를 반환한다.*/
         return ((Number) value).intValue() == 1;
     }
+
     /*SELECT id
     FROM article
     WHERE id IN (?, ?, ?)
@@ -212,7 +233,7 @@ public class Sql {
         List<Long> longs = new ArrayList<>();
 
         //rows 안에 있는 Map<String, Object>에서 value를 꺼내서 longs에 추가한다.
-        for (int i = 0 ; i < rows.size(); i++) {
+        for (int i = 0; i < rows.size(); i++) {
             Map<String, Object> row = rows.get(i);
             Object value = row.values().iterator().next();
             longs.add((Long) value);

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -201,8 +201,22 @@ public class Sql {
         그 값이 1인지 비교해서 true 또는 false를 반환한다.*/
         return ((Number) value).intValue() == 1;
     }
-
+    /*SELECT id
+    FROM article
+    WHERE id IN (?, ?, ?)
+    ORDER BY FIELD(id, ?, ?, ?)*/
     public List<Long> selectLongs() {
-        return null;
+        //selectRows()로 조회 결과를 List<Map<String, Object>>로 가져온다.
+        List<Map<String, Object>> rows = selectRows();
+        //최종 결과 값을 담을 LIST 생성
+        List<Long> longs = new ArrayList<>();
+
+        //rows 안에 있는 Map<String, Object>에서 value를 꺼내서 longs에 추가한다.
+        for (int i = 0 ; i < rows.size(); i++) {
+            Map<String, Object> row = rows.get(i);
+            Object value = row.values().iterator().next();
+            longs.add((Long) value);
+        }
+        return longs;
     }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -166,7 +166,23 @@ public class Sql {
     }
 
     public <T> T selectRow(Class<T> clazz) {
-        return null;
+        List<Map<String, Object>> rows = selectRows();
+        Article article = new Article();
+
+        if (rows.isEmpty()) {
+            return null;
+        }
+
+        Map<String, Object> row = rows.get(0);
+
+        article.setId((Long) row.get("id"));
+        article.setTitle((String) row.get("title"));
+        article.setBody((String) row.get("body"));
+        article.setCreatedDate((LocalDateTime) row.get("createdDate"));
+        article.setModifiedDate((LocalDateTime) row.get("modifiedDate"));
+        article.setBlind((Boolean) row.get("isBlind"));
+
+        return (T) article;
     }
 
     public LocalDateTime selectDatetime() {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -2,9 +2,11 @@ package com.back.simpleDb;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.Statement;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -32,6 +34,7 @@ public class Sql {
         return this;
     }
 
+    // i + 1은 java의 인덱스는 0번부 시작
     public long insert() {
         try (PreparedStatement ps = simpleDb.getConnection()
                 .prepareStatement(sqlBuilder.toString(), Statement.RETURN_GENERATED_KEYS)) {
@@ -54,7 +57,7 @@ public class Sql {
      * update인지 delete인지 문법을 해석하고 실제로 테이블을 바꾸는 일은 MySql이 한다
      */
 
-    private int executeUpdate(){
+    private int executeUpdate() {
         try (PreparedStatement ps = simpleDb.getConnection().prepareStatement(sqlBuilder.toString())) {
             for (int i = 0; i < params.size(); i++) {
                 ps.setObject(i + 1, params.get(i));
@@ -74,7 +77,37 @@ public class Sql {
     }
 
     public List<Map<String, Object>> selectRows() {
-        return null;
+        try (PreparedStatement ps = simpleDb.getConnection().prepareStatement(sqlBuilder.toString())) {
+            for (int i = 0; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            //select 조회문 사용
+            ResultSet rs = ps.executeQuery();
+            //조회 컬럼 정보 가져옴
+            ResultSetMetaData metaData = rs.getMetaData();
+
+            //조회 결과의 컬럼 개수 가져옴
+            int columCount = metaData.getColumnCount();
+            //최종 결과 담을 리스트 만듬
+            List<Map<String, Object>> rows = new ArrayList<>();
+
+            while (rs.next()) {
+                //LinkedHashMap은 입력한 순서대로 key, value를 보관하는 Map
+                Map<String, Object> row = new LinkedHashMap<>();
+
+                for (int i = 1; i <= columCount; i++) {
+                    String ColumName = metaData.getColumnLabel(i);
+                    //컬럼마다 타입 다름
+                    Object value = rs.getObject(i);
+
+                    row.put(ColumName, value);
+                }
+                rows.add(row);
+            }
+            return rows;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public <T> List<T> selectRows(Class<T> clazz) {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -5,6 +5,11 @@ import java.util.List;
 import java.util.Map;
 
 public class Sql {
+    private final SimpleDb simpleDb;
+
+    public Sql(SimpleDb simpleDb) {
+        this.simpleDb = simpleDb;
+    }
 
     public Sql append(String sql, Object... params) {
         return this;

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -157,7 +157,15 @@ public class Sql {
     }
 
     public String selectString() {
-        return null;
+        Map<String, Object> row = selectRow();
+
+        if(row == null) {
+            return null;
+        }
+
+        Object value = row.values().iterator().next();
+
+        return (String) value;
     }
 
     public Boolean selectBoolean() {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -177,7 +177,11 @@ public class Sql {
 
         Object value = row.values().iterator().next();
 
-        return (Boolean) value;
+        if(value instanceof Boolean) {
+            return (Boolean) value;
+        }
+
+        return ((Number)value).intValue() == 1;
     }
 
     public List<Long> selectLongs() {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -55,13 +55,25 @@ public class Sql {
                 ps.setObject(i + 1, params.get(i));
             }
             return ps.executeUpdate();
-        }catch (Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
+    /*
+     * java 로직은 sql 문자열과 파라미터를 DB에 전달하고 실행 결과를 받는 역할
+     * update인지 delete인지 문법을 해석하고 실제로 테이블을 바꾸는 일은 MySql이 한다
+     */
+
     public int delete() {
-        return 0;
+        try (PreparedStatement ps = simpleDb.getConnection().prepareStatement(sqlBuilder.toString())) {
+            for (int i = 0; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            return ps.executeUpdate();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public List<Map<String, Object>> selectRows() {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -21,7 +21,7 @@ public class Sql {
 
     public Sql append(String sql, Object... params) {
         sqlBuilder.append(sql).append(" ");
-        for(int i = 0; i < params.length; i++) {
+        for (int i = 0; i < params.length; i++) {
             Object param = params[i];
             this.params.add(param);
         }
@@ -33,24 +33,31 @@ public class Sql {
     }
 
     public long insert() {
-        try(PreparedStatement ps = simpleDb.getConnection()
+        try (PreparedStatement ps = simpleDb.getConnection()
                 .prepareStatement(sqlBuilder.toString(), Statement.RETURN_GENERATED_KEYS)) {
-        for(int i = 0 ; i < params.size(); i++) {
+            for (int i = 0; i < params.size(); i++) {
                 ps.setObject(i + 1, params.get(i));
             }
             ps.executeUpdate();
             ResultSet rs = ps.getGeneratedKeys();
-            if(rs.next()) {
+            if (rs.next()) {
                 return rs.getLong(1);
             }
             return 0;
-        }catch (Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
     public int update() {
-        return 0;
+        try (PreparedStatement ps = simpleDb.getConnection().prepareStatement(sqlBuilder.toString())) {
+            for (int i = 0; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            return ps.executeUpdate();
+        }catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public int delete() {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -31,6 +31,23 @@ public class Sql {
     }
 
     public Sql appendIn(String sql, Object... params) {
+        String questionMarks = "?";
+        //파라미터 개수만큼 "?" 늘리기
+        for (int i = 1; i < params.length; i++) {
+            //문자열 뒤에 ", ?" 붙이기
+            questionMarks += ", ?";
+        }
+        //기존 SQL 안의 "?"를 questionMarks로 바꿔주기
+        //"WHERE id IN (?)" -> "WHERE id IN (?, ?, ?)"
+        sql = sql.replace("?", questionMarks);
+
+        sqlBuilder.append(sql).append(" ");
+
+        for (int i = 0; i < params.length; i++) {
+            Object param = params[i];
+            this.params.add(param);
+        }
+
         return this;
     }
 
@@ -115,14 +132,14 @@ public class Sql {
     }
 
     /*
-    * selectRows()는 MySQL이 찾아서 반환한 ResultSet을 컬럼명과 컬럼값으로 묶어서
-    * List<Map<String, Object>>로 바꿔준다.
-    * selectRow()는 그 결과 리스트에서 첫 번째 row만 꺼내서 반환한다.
-    */
+     * selectRows()는 MySQL이 찾아서 반환한 ResultSet을 컬럼명과 컬럼값으로 묶어서
+     * List<Map<String, Object>>로 바꿔준다.
+     * selectRow()는 그 결과 리스트에서 첫 번째 row만 꺼내서 반환한다.
+     */
     public Map<String, Object> selectRow() {
         List<Map<String, Object>> rows = selectRows();
 
-        if(rows.isEmpty()) {
+        if (rows.isEmpty()) {
             return null;
         }
         return rows.get(0);
@@ -135,7 +152,7 @@ public class Sql {
     public LocalDateTime selectDatetime() {
         Map<String, Object> row = selectRow();
 
-        if(row == null) {
+        if (row == null) {
             return null;
         }
 
@@ -147,7 +164,7 @@ public class Sql {
     public Long selectLong() {
         Map<String, Object> row = selectRow();
 
-        if(row == null) {
+        if (row == null) {
             return null;
         }
 
@@ -159,7 +176,7 @@ public class Sql {
     public String selectString() {
         Map<String, Object> row = selectRow();
 
-        if(row == null) {
+        if (row == null) {
             return null;
         }
 
@@ -171,18 +188,18 @@ public class Sql {
     public Boolean selectBoolean() {
         Map<String, Object> row = selectRow();
 
-        if(row == null) {
+        if (row == null) {
             return null;
         }
         //첫 번째 오는 값을 value로 집어넣기
         Object value = row.values().iterator().next();
 
-        if(value instanceof Boolean) {
+        if (value instanceof Boolean) {
             return (Boolean) value;
         }
         /*value로 온 것을 숫자로 보고 int 값으로 꺼낸 뒤,
         그 값이 1인지 비교해서 true 또는 false를 반환한다.*/
-        return ((Number)value).intValue() == 1;
+        return ((Number) value).intValue() == 1;
     }
 
     public List<Long> selectLongs() {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -145,7 +145,15 @@ public class Sql {
     }
 
     public Long selectLong() {
-        return null;
+        Map<String, Object> row = selectRow();
+
+        if(row == null) {
+            return null;
+        }
+
+        Object value = row.values().iterator().next();
+
+        return (Long) value;
     }
 
     public String selectString() {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -174,13 +174,14 @@ public class Sql {
         if(row == null) {
             return null;
         }
-
+        //첫 번째 오는 값을 value로 집어넣기
         Object value = row.values().iterator().next();
 
         if(value instanceof Boolean) {
             return (Boolean) value;
         }
-
+        /*value로 온 것을 숫자로 보고 int 값으로 꺼낸 뒤,
+        그 값이 1인지 비교해서 true 또는 false를 반환한다.*/
         return ((Number)value).intValue() == 1;
     }
 

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -1,0 +1,64 @@
+package com.back.simpleDb;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class Sql {
+
+    public Sql append(String sql, Object... params) {
+        return this;
+    }
+
+    public Sql appendIn(String sql, Object... params) {
+        return this;
+    }
+
+    public long insert() {
+        return 0;
+    }
+
+    public int update() {
+        return 0;
+    }
+
+    public int delete() {
+        return 0;
+    }
+
+    public List<Map<String, Object>> selectRows() {
+        return null;
+    }
+
+    public <T> List<T> selectRows(Class<T> clazz) {
+        return null;
+    }
+
+    public Map<String, Object> selectRow() {
+        return null;
+    }
+
+    public <T> T selectRow(Class<T> clazz) {
+        return null;
+    }
+
+    public LocalDateTime selectDatetime() {
+        return null;
+    }
+
+    public Long selectLong() {
+        return null;
+    }
+
+    public String selectString() {
+        return null;
+    }
+
+    public Boolean selectBoolean() {
+        return null;
+    }
+
+    public List<Long> selectLongs() {
+        return null;
+    }
+}

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -1,17 +1,30 @@
 package com.back.simpleDb;
 
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public class Sql {
     private final SimpleDb simpleDb;
+    //append가 여러번 호출되니 이어붙여 보관
+    private final StringBuilder sqlBuilder = new StringBuilder();
+    //누적해놓고 바인딩할 값 순서대로 보관
+    private final List<Object> params = new ArrayList<>();
 
     public Sql(SimpleDb simpleDb) {
         this.simpleDb = simpleDb;
     }
 
     public Sql append(String sql, Object... params) {
+        sqlBuilder.append(sql).append(" ");
+        for(int i = 0; i < params.length; i++) {
+            Object param = params[i];
+            this.params.add(param);
+        }
         return this;
     }
 
@@ -20,7 +33,20 @@ public class Sql {
     }
 
     public long insert() {
-        return 0;
+        try(PreparedStatement ps = simpleDb.getConnection()
+                .prepareStatement(sqlBuilder.toString(), Statement.RETURN_GENERATED_KEYS)) {
+        for(int i = 0 ; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            ps.executeUpdate();
+            ResultSet rs = ps.getGeneratedKeys();
+            if(rs.next()) {
+                return rs.getLong(1);
+            }
+            return 0;
+        }catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public int update() {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -169,7 +169,15 @@ public class Sql {
     }
 
     public Boolean selectBoolean() {
-        return null;
+        Map<String, Object> row = selectRow();
+
+        if(row == null) {
+            return null;
+        }
+
+        Object value = row.values().iterator().next();
+
+        return (Boolean) value;
     }
 
     public List<Long> selectLongs() {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -87,7 +87,7 @@ public class Sql {
             ResultSetMetaData metaData = rs.getMetaData();
 
             //조회 결과의 컬럼 개수 가져옴
-            int columCount = metaData.getColumnCount();
+            int columnCount = metaData.getColumnCount();
             //최종 결과 담을 리스트 만듬
             List<Map<String, Object>> rows = new ArrayList<>();
 
@@ -95,12 +95,12 @@ public class Sql {
                 //LinkedHashMap은 입력한 순서대로 key, value를 보관하는 Map
                 Map<String, Object> row = new LinkedHashMap<>();
 
-                for (int i = 1; i <= columCount; i++) {
-                    String ColumName = metaData.getColumnLabel(i);
+                for (int i = 1; i <= columnCount; i++) {
+                    String columnName = metaData.getColumnLabel(i);
                     //컬럼마다 타입 다름
                     Object value = rs.getObject(i);
 
-                    row.put(ColumName, value);
+                    row.put(columnName, value);
                 }
                 rows.add(row);
             }
@@ -114,8 +114,18 @@ public class Sql {
         return null;
     }
 
+    /*
+    * selectRows()는 MySQL이 찾아서 반환한 ResultSet을 컬럼명과 컬럼값으로 묶어서
+    * List<Map<String, Object>>로 바꿔준다.
+    * selectRow()는 그 결과 리스트에서 첫 번째 row만 꺼내서 반환한다.
+    */
     public Map<String, Object> selectRow() {
-        return null;
+        List<Map<String, Object>> rows = selectRows();
+
+        if(rows.isEmpty()) {
+            return null;
+        }
+        return rows.get(0);
     }
 
     public <T> T selectRow(Class<T> clazz) {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -49,7 +49,12 @@ public class Sql {
         }
     }
 
-    public int update() {
+    /*
+     * java 로직은 sql 문자열과 파라미터를 DB에 전달하고 실행 결과를 받는 역할
+     * update인지 delete인지 문법을 해석하고 실제로 테이블을 바꾸는 일은 MySql이 한다
+     */
+
+    private int executeUpdate(){
         try (PreparedStatement ps = simpleDb.getConnection().prepareStatement(sqlBuilder.toString())) {
             for (int i = 0; i < params.size(); i++) {
                 ps.setObject(i + 1, params.get(i));
@@ -60,20 +65,12 @@ public class Sql {
         }
     }
 
-    /*
-     * java 로직은 sql 문자열과 파라미터를 DB에 전달하고 실행 결과를 받는 역할
-     * update인지 delete인지 문법을 해석하고 실제로 테이블을 바꾸는 일은 MySql이 한다
-     */
+    public int update() {
+        return executeUpdate();
+    }
 
     public int delete() {
-        try (PreparedStatement ps = simpleDb.getConnection().prepareStatement(sqlBuilder.toString())) {
-            for (int i = 0; i < params.size(); i++) {
-                ps.setObject(i + 1, params.get(i));
-            }
-            return ps.executeUpdate();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        return executeUpdate();
     }
 
     public List<Map<String, Object>> selectRows() {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -133,7 +133,15 @@ public class Sql {
     }
 
     public LocalDateTime selectDatetime() {
-        return null;
+        Map<String, Object> row = selectRow();
+
+        if(row == null) {
+            return null;
+        }
+
+        Object value = row.values().iterator().next();
+
+        return (LocalDateTime) value;
     }
 
     public Long selectLong() {

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -1,7 +1,6 @@
 package com.back.simpleDb;
 
-import com.back.domain.Article;
-
+import java.lang.reflect.Field;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -19,26 +18,41 @@ public class Sql {
     //누적해놓고 바인딩할 값 순서대로 보관
     private final List<Object> params = new ArrayList<>();
 
+    //첫 번째 오는 값을 집어넣기
+    private Object getFirstValue(Map<String, Object> row) {
+        return row.values().iterator().next();
+    }
+
+    private void bindParams(PreparedStatement ps) throws Exception {
+        for (int i = 0; i < params.size(); i++) {
+            ps.setObject(i + 1, params.get(i));
+        }
+    }
+
     public Sql(SimpleDb simpleDb) {
         this.simpleDb = simpleDb;
     }
 
     public Sql append(String sql, Object... params) {
         sqlBuilder.append(sql).append(" ");
+
         for (int i = 0; i < params.length; i++) {
             Object param = params[i];
             this.params.add(param);
         }
+
         return this;
     }
 
     public Sql appendIn(String sql, Object... params) {
         String questionMarks = "?";
+
         //파라미터 개수만큼 "?" 늘리기
         for (int i = 1; i < params.length; i++) {
             //문자열 뒤에 ", ?" 붙이기
             questionMarks += ", ?";
         }
+
         //기존 SQL 안의 "?"를 questionMarks로 바꿔주기
         //"WHERE id IN (?)" -> "WHERE id IN (?, ?, ?)"
         sql = sql.replace("?", questionMarks);
@@ -57,15 +71,17 @@ public class Sql {
     public long insert() {
         try (PreparedStatement ps = simpleDb.getConnection()
                 .prepareStatement(sqlBuilder.toString(), Statement.RETURN_GENERATED_KEYS)) {
-            for (int i = 0; i < params.size(); i++) {
-                ps.setObject(i + 1, params.get(i));
-            }
+            bindParams(ps);
+
             ps.executeUpdate();
+
             ResultSet rs = ps.getGeneratedKeys();
+
             if (rs.next()) {
                 return rs.getLong(1);
             }
             return 0;
+
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -75,13 +91,11 @@ public class Sql {
      * java 로직은 sql 문자열과 파라미터를 DB에 전달하고 실행 결과를 받는 역할
      * update인지 delete인지 문법을 해석하고 실제로 테이블을 바꾸는 일은 MySql이 한다
      */
-
     private int executeUpdate() {
         try (PreparedStatement ps = simpleDb.getConnection().prepareStatement(sqlBuilder.toString())) {
-            for (int i = 0; i < params.size(); i++) {
-                ps.setObject(i + 1, params.get(i));
-            }
+            bindParams(ps);
             return ps.executeUpdate();
+
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -97,9 +111,7 @@ public class Sql {
 
     public List<Map<String, Object>> selectRows() {
         try (PreparedStatement ps = simpleDb.getConnection().prepareStatement(sqlBuilder.toString())) {
-            for (int i = 0; i < params.size(); i++) {
-                ps.setObject(i + 1, params.get(i));
-            }
+            bindParams(ps);
             //select 조회문 사용
             ResultSet rs = ps.executeQuery();
             //조회 컬럼 정보 가져옴
@@ -124,6 +136,7 @@ public class Sql {
                 rows.add(row);
             }
             return rows;
+
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -133,22 +146,14 @@ public class Sql {
     selectRows()로 가져온 결과를 List<Map<String, Object>>로 가져온다.*/
     public <T> List<T> selectRows(Class<T> clazz) {
         List<Map<String, Object>> rows = selectRows();
-        List<Article> articles = new ArrayList<>();
+        List<T> objects = new ArrayList<>();
 
         for(int i = 0 ; i < rows.size(); i++) {
             Map<String, Object> row = rows.get(i);
-            Article article = new Article();
-
-            article.setId((Long) row.get("id"));
-            article.setTitle((String) row.get("title"));
-            article.setBody((String) row.get("body"));
-            article.setCreatedDate((LocalDateTime) row.get("createdDate"));
-            article.setModifiedDate((LocalDateTime) row.get("modifiedDate"));
-            article.setBlind((Boolean) row.get("isBlind"));
-
-            articles.add(article);
+            T obj = mapToObject(row, clazz);
+            objects.add(obj);
         }
-        return (List<T>) articles;
+        return objects;
     }
 
     /*
@@ -166,23 +171,13 @@ public class Sql {
     }
 
     public <T> T selectRow(Class<T> clazz) {
-        List<Map<String, Object>> rows = selectRows();
-        Article article = new Article();
+        Map<String, Object> row = selectRow();
 
-        if (rows.isEmpty()) {
+        if(row == null){
             return null;
         }
 
-        Map<String, Object> row = rows.get(0);
-
-        article.setId((Long) row.get("id"));
-        article.setTitle((String) row.get("title"));
-        article.setBody((String) row.get("body"));
-        article.setCreatedDate((LocalDateTime) row.get("createdDate"));
-        article.setModifiedDate((LocalDateTime) row.get("modifiedDate"));
-        article.setBlind((Boolean) row.get("isBlind"));
-
-        return (T) article;
+        return mapToObject(row, clazz);
     }
 
     public LocalDateTime selectDatetime() {
@@ -192,9 +187,7 @@ public class Sql {
             return null;
         }
 
-        Object value = row.values().iterator().next();
-
-        return (LocalDateTime) value;
+        return (LocalDateTime) getFirstValue(row);
     }
 
     public Long selectLong() {
@@ -204,9 +197,7 @@ public class Sql {
             return null;
         }
 
-        Object value = row.values().iterator().next();
-
-        return (Long) value;
+        return (Long) getFirstValue(row);
     }
 
     public String selectString() {
@@ -216,9 +207,7 @@ public class Sql {
             return null;
         }
 
-        Object value = row.values().iterator().next();
-
-        return (String) value;
+        return (String) getFirstValue(row);
     }
 
     public Boolean selectBoolean() {
@@ -227,8 +216,8 @@ public class Sql {
         if (row == null) {
             return null;
         }
-        //첫 번째 오는 값을 value로 집어넣기
-        Object value = row.values().iterator().next();
+
+        Object value = getFirstValue(row);
 
         if (value instanceof Boolean) {
             return (Boolean) value;
@@ -251,9 +240,29 @@ public class Sql {
         //rows 안에 있는 Map<String, Object>에서 value를 꺼내서 longs에 추가한다.
         for (int i = 0; i < rows.size(); i++) {
             Map<String, Object> row = rows.get(i);
-            Object value = row.values().iterator().next();
-            longs.add((Long) value);
+            longs.add((Long) getFirstValue(row));
         }
+
         return longs;
+    }
+
+    private <T> T mapToObject(Map<String, Object> row, Class<T> clazz) {
+        try{
+            T obj = clazz.getDeclaredConstructor().newInstance();
+
+            String[] columnNames = row.keySet().toArray(new String[0]);
+
+            for(int i = 0; i < columnNames.length; i++) {
+                String columnName = columnNames[i];
+                Object value = row.get(columnName);
+
+                Field field = clazz.getDeclaredField(columnName);
+                field.setAccessible(true);
+                field.set(obj, value);
+            }
+            return obj;
+        }catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -276,21 +276,21 @@ public class SimpleDbTest {
         assertThat(isBlind).isEqualTo(true);
     }
 
-//    @Test
-//    @DisplayName("selectBoolean, 3rd")
-//    public void t011() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT 1 = 0
-//        */
-//        sql.append("SELECT 1 = 0");
-//
-//        Boolean isBlind = sql.selectBoolean();
-//
-//        assertThat(isBlind).isEqualTo(false);
-//    }
-//
+    @Test
+    @DisplayName("selectBoolean, 3rd")
+    public void t011() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT 1 = 0
+        */
+        sql.append("SELECT 1 = 0");
+
+        Boolean isBlind = sql.selectBoolean();
+
+        assertThat(isBlind).isEqualTo(false);
+    }
+
 //    @Test
 //    @DisplayName("select, LIKE 사용법")
 //    public void t012() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -108,28 +108,28 @@ public class SimpleDbTest {
         assertThat(affectedRowsCount).isEqualTo(3);
     }
 
-//    @Test
-//    @DisplayName("delete")
-//    public void t003() {
-//        Sql sql = simpleDb.genSql();
-//
-//        // id가 0, 1, 3인 글 삭제
-//        // id가 0인 글은 없으니, 실제로는 2개의 글이 삭제됨
-//        /*
-//        == rawSql ==
-//        DELETE FROM article
-//        WHERE id IN ('0', '1', '3')
-//        */
-//        sql.append("DELETE")
-//                .append("FROM article")
-//                .append("WHERE id IN (?, ?, ?)", 0, 1, 3);
-//
-//        // 삭제된 row 개수
-//        int affectedRowsCount = sql.delete();
-//
-//        assertThat(affectedRowsCount).isEqualTo(2);
-//    }
-//
+    @Test
+    @DisplayName("delete")
+    public void t003() {
+        Sql sql = simpleDb.genSql();
+
+        // id가 0, 1, 3인 글 삭제
+        // id가 0인 글은 없으니, 실제로는 2개의 글이 삭제됨
+        /*
+        == rawSql ==
+        DELETE FROM article
+        WHERE id IN ('0', '1', '3')
+        */
+        sql.append("DELETE")
+                .append("FROM article")
+                .append("WHERE id IN (?, ?, ?)", 0, 1, 3);
+
+        // 삭제된 row 개수
+        int affectedRowsCount = sql.delete();
+
+        assertThat(affectedRowsCount).isEqualTo(2);
+    }
+
 //    @Test
 //    @DisplayName("selectRows")
 //    public void t004() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -479,34 +479,34 @@ public class SimpleDbTest {
         assertThat(successCounter.get()).isEqualTo(numberOfThreads);
     }
 
-//    @Test
-//    @DisplayName("rollback")
-//    public void t018() {
-//        // SimpleDB에서 SQL 객체를 생성합니다.
-//        long oldCount = simpleDb.genSql()
-//                .append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .selectLong();
-//
-//        // 트랜잭션을 시작합니다.
-//        simpleDb.startTransaction();
-//
-//        simpleDb.genSql()
-//                .append("INSERT INTO article ")
-//                .append("(createdDate, modifiedDate, title, body)")
-//                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
-//                .insert();
-//
-//        simpleDb.rollback();
-//
-//        long newCount = simpleDb.genSql()
-//                .append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .selectLong();
-//
-//        assertThat(newCount).isEqualTo(oldCount);
-//    }
-//
+    @Test
+    @DisplayName("rollback")
+    public void t018() {
+        // SimpleDB에서 SQL 객체를 생성합니다.
+        long oldCount = simpleDb.genSql()
+                .append("SELECT COUNT(*)")
+                .append("FROM article")
+                .selectLong();
+
+        // 트랜잭션을 시작합니다.
+        simpleDb.startTransaction();
+
+        simpleDb.genSql()
+                .append("INSERT INTO article ")
+                .append("(createdDate, modifiedDate, title, body)")
+                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
+                .insert();
+
+        simpleDb.rollback();
+
+        long newCount = simpleDb.genSql()
+                .append("SELECT COUNT(*)")
+                .append("FROM article")
+                .selectLong();
+
+        assertThat(newCount).isEqualTo(oldCount);
+    }
+
 //    @Test
 //    @DisplayName("commit")
 //    public void t019() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -507,31 +507,31 @@ public class SimpleDbTest {
         assertThat(newCount).isEqualTo(oldCount);
     }
 
-//    @Test
-//    @DisplayName("commit")
-//    public void t019() {
-//        // SimpleDB에서 SQL 객체를 생성합니다.
-//        long oldCount = simpleDb.genSql()
-//                .append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .selectLong();
-//
-//        // 트랜잭션을 시작합니다.
-//        simpleDb.startTransaction();
-//
-//        simpleDb.genSql()
-//                .append("INSERT INTO article ")
-//                .append("(createdDate, modifiedDate, title, body)")
-//                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
-//                .insert();
-//
-//        simpleDb.commit();
-//
-//        long newCount = simpleDb.genSql()
-//                .append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .selectLong();
-//
-//        assertThat(newCount).isEqualTo(oldCount + 1);
-//    }
+    @Test
+    @DisplayName("commit")
+    public void t019() {
+        // SimpleDB에서 SQL 객체를 생성합니다.
+        long oldCount = simpleDb.genSql()
+                .append("SELECT COUNT(*)")
+                .append("FROM article")
+                .selectLong();
+
+        // 트랜잭션을 시작합니다.
+        simpleDb.startTransaction();
+
+        simpleDb.genSql()
+                .append("INSERT INTO article ")
+                .append("(createdDate, modifiedDate, title, body)")
+                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
+                .insert();
+
+        simpleDb.commit();
+
+        long newCount = simpleDb.genSql()
+                .append("SELECT COUNT(*)")
+                .append("FROM article")
+                .selectLong();
+
+        assertThat(newCount).isEqualTo(oldCount + 1);
+    }
 }

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -1,18 +1,7 @@
 package com.back.simpleDb;
 
-import com.back.domain.Article;
 import org.junit.jupiter.api.*;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -119,419 +108,419 @@ public class SimpleDbTest {
         assertThat(affectedRowsCount).isEqualTo(3);
     }
 
-    @Test
-    @DisplayName("delete")
-    public void t003() {
-        Sql sql = simpleDb.genSql();
-
-        // id가 0, 1, 3인 글 삭제
-        // id가 0인 글은 없으니, 실제로는 2개의 글이 삭제됨
-        /*
-        == rawSql ==
-        DELETE FROM article
-        WHERE id IN ('0', '1', '3')
-        */
-        sql.append("DELETE")
-                .append("FROM article")
-                .append("WHERE id IN (?, ?, ?)", 0, 1, 3);
-
-        // 삭제된 row 개수
-        int affectedRowsCount = sql.delete();
-
-        assertThat(affectedRowsCount).isEqualTo(2);
-    }
-
-    @Test
-    @DisplayName("selectRows")
-    public void t004() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT *
-        FROM article
-        ORDER BY id ASC
-        LIMIT 3
-        */
-        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
-        List<Map<String, Object>> articleRows = sql.selectRows();
-
-        IntStream.range(0, articleRows.size()).forEach(i -> {
-            long id = i + 1;
-
-            Map<String, Object> articleRow = articleRows.get(i);
-
-            assertThat(articleRow.get("id")).isEqualTo(id);
-            assertThat(articleRow.get("title")).isEqualTo("제목%d".formatted(id));
-            assertThat(articleRow.get("body")).isEqualTo("내용%d".formatted(id));
-            assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
-            assertThat(articleRow.get("createdDate")).isNotNull();
-            assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
-            assertThat(articleRow.get("modifiedDate")).isNotNull();
-            assertThat(articleRow.get("isBlind")).isEqualTo(false);
-        });
-    }
-
-    @Test
-    @DisplayName("selectRow")
-    public void t005() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT *
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT * FROM article WHERE id = 1");
-        Map<String, Object> articleRow = sql.selectRow();
-
-        assertThat(articleRow.get("id")).isEqualTo(1L);
-        assertThat(articleRow.get("title")).isEqualTo("제목1");
-        assertThat(articleRow.get("body")).isEqualTo("내용1");
-        assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
-        assertThat(articleRow.get("createdDate")).isNotNull();
-        assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
-        assertThat(articleRow.get("modifiedDate")).isNotNull();
-        assertThat(articleRow.get("isBlind")).isEqualTo(false);
-    }
-
-    @Test
-    @DisplayName("selectDatetime")
-    public void t006() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT NOW()
-        */
-        sql.append("SELECT NOW()");
-
-        LocalDateTime datetime = sql.selectDatetime();
-
-        long diff = ChronoUnit.SECONDS.between(datetime, LocalDateTime.now());
-
-        assertThat(diff).isLessThanOrEqualTo(1L);
-    }
-
-    @Test
-    @DisplayName("selectLong")
-    public void t007() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT id
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT id")
-                .append("FROM article")
-                .append("WHERE id = 1");
-
-        Long id = sql.selectLong();
-
-        assertThat(id).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("selectString")
-    public void t008() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT title
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT title")
-                .append("FROM article")
-                .append("WHERE id = 1");
-
-        String title = sql.selectString();
-
-        assertThat(title).isEqualTo("제목1");
-    }
-
-    @Test
-    @DisplayName("selectBoolean")
-    public void t009() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT isBlind
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT isBlind")
-                .append("FROM article")
-                .append("WHERE id = 1");
-
-        Boolean isBlind = sql.selectBoolean();
-
-        assertThat(isBlind).isEqualTo(false);
-    }
-
-    @Test
-    @DisplayName("selectBoolean, 2nd")
-    public void t010() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT 1 = 1
-        */
-        sql.append("SELECT 1 = 1");
-
-        Boolean isBlind = sql.selectBoolean();
-
-        assertThat(isBlind).isEqualTo(true);
-    }
-
-    @Test
-    @DisplayName("selectBoolean, 3rd")
-    public void t011() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT 1 = 0
-        */
-        sql.append("SELECT 1 = 0");
-
-        Boolean isBlind = sql.selectBoolean();
-
-        assertThat(isBlind).isEqualTo(false);
-    }
-
-    @Test
-    @DisplayName("select, LIKE 사용법")
-    public void t012() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT COUNT(*)
-        FROM article
-        WHERE id BETWEEN '1' AND '3'
-        AND title LIKE CONCAT('%', '제목' '%')
-        */
-        sql.append("SELECT COUNT(*)")
-                .append("FROM article")
-                .append("WHERE id BETWEEN ? AND ?", 1, 3)
-                .append("AND title LIKE CONCAT('%', ? '%')", "제목");
-
-        long count = sql.selectLong();
-
-        assertThat(count).isEqualTo(3);
-    }
-
-    @Test
-    @DisplayName("appendIn")
-    public void t013() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT COUNT(*)
-        FROM article
-        WHERE id IN ('1', '2', '3')
-        */
-        sql.append("SELECT COUNT(*)")
-                .append("FROM article")
-                .appendIn("WHERE id IN (?)", 1, 2, 3);
-
-        long count = sql.selectLong();
-
-        assertThat(count).isEqualTo(3);
-    }
-
-    @Test
-    @DisplayName("selectLongs, ORDER BY FIELD 사용법")
-    public void t014() {
-        Long[] ids = new Long[]{2L, 1L, 3L};
-
-        Sql sql = simpleDb.genSql();
-        /*
-        SELECT id
-        FROM article
-        WHERE id IN ('2', '3', '1')
-        ORDER BY FIELD (id, '2', '3', '1')
-        */
-        sql.append("SELECT id")
-                .append("FROM article")
-                .appendIn("WHERE id IN (?)", ids)
-                .appendIn("ORDER BY FIELD (id, ?)", ids);
-
-        List<Long> foundIds = sql.selectLongs();
-
-        assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
-    }
-
-    @Test
-    @DisplayName("selectRows, Article")
-    public void t015() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT *
-        FROM article
-        ORDER BY id ASC
-        LIMIT 3
-        */
-        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
-        List<Article> articleRows = sql.selectRows(Article.class);
-
-        IntStream.range(0, articleRows.size()).forEach(i -> {
-            long id = i + 1;
-
-            Article article = articleRows.get(i);
-
-            assertThat(article.getId()).isEqualTo(id);
-            assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
-            assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
-            assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
-            assertThat(article.getCreatedDate()).isNotNull();
-            assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
-            assertThat(article.getModifiedDate()).isNotNull();
-            assertThat(article.isBlind()).isEqualTo(false);
-        });
-    }
-
-    @Test
-    @DisplayName("selectRow, Article")
-    public void t016() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT *
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT * FROM article WHERE id = 1");
-        Article article = sql.selectRow(Article.class);
-
-        Long id = 1L;
-
-        assertThat(article.getId()).isEqualTo(id);
-        assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
-        assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
-        assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
-        assertThat(article.getCreatedDate()).isNotNull();
-        assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
-        assertThat(article.getModifiedDate()).isNotNull();
-        assertThat(article.isBlind()).isEqualTo(false);
-    }
-
-    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
-    @Test
-    @DisplayName("use in multi threading")
-    public void t017() throws InterruptedException {
-        // 쓰레드 풀의 크기를 정의합니다.
-        int numberOfThreads = 10;
-
-        // 고정 크기의 쓰레드 풀을 생성합니다.
-        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
-
-        // 성공한 작업의 수를 세는 원자적 카운터를 생성합니다.
-        AtomicInteger successCounter = new AtomicInteger(0);
-
-        // 동시에 실행되는 작업의 수를 세는 데 사용되는 래치를 생성합니다.
-        CountDownLatch latch = new CountDownLatch(numberOfThreads);
-
-        // 각 쓰레드에서 실행될 작업을 정의합니다.
-        Runnable task = () -> {
-            try {
-                // SimpleDB에서 SQL 객체를 생성합니다.
-                Sql sql = simpleDb.genSql();
-
-                // SQL 쿼리를 작성합니다.
-                sql.append("SELECT * FROM article WHERE id = 1");
-
-                // 쿼리를 실행하여 결과를 Article 객체로 매핑합니다.
-                Article article = sql.selectRow(Article.class);
-
-                // 기대하는 Article 객체의 ID를 정의합니다.
-                Long id = 1L;
-
-                // Article 객체의 값이 기대하는 값과 일치하는지 확인하고,
-                // 일치하는 경우 성공 카운터를 증가시킵니다.
-                if (article.getId() == id &&
-                        article.getTitle().equals("제목%d".formatted(id)) &&
-                        article.getBody().equals("내용%d".formatted(id)) &&
-                        article.getCreatedDate() != null &&
-                        article.getModifiedDate() != null &&
-                        !article.isBlind()) {
-                    successCounter.incrementAndGet();
-                }
-            } finally {
-                // 커넥션 종료
-                simpleDb.close();
-                // 작업이 완료되면 래치 카운터를 감소시킵니다.
-                latch.countDown();
-            }
-        };
-
-        // 쓰레드 풀에서 쓰레드를 할당받아 작업을 실행합니다.
-        for (int i = 0; i < numberOfThreads; i++) {
-            executorService.submit(task);
-        }
-
-        // 모든 작업이 완료될 때까지 대기하거나, 최대 10초 동안 대기합니다.
-        latch.await(10, TimeUnit.SECONDS);
-
-        // 쓰레드 풀을 종료시킵니다.
-        executorService.shutdown();
-
-        // 성공 카운터가 쓰레드 수와 동일한지 확인합니다.
-        assertThat(successCounter.get()).isEqualTo(numberOfThreads);
-    }
-
-    @Test
-    @DisplayName("rollback")
-    public void t018() {
-        // SimpleDB에서 SQL 객체를 생성합니다.
-        long oldCount = simpleDb.genSql()
-                .append("SELECT COUNT(*)")
-                .append("FROM article")
-                .selectLong();
-
-        // 트랜잭션을 시작합니다.
-        simpleDb.startTransaction();
-
-        simpleDb.genSql()
-                .append("INSERT INTO article ")
-                .append("(createdDate, modifiedDate, title, body)")
-                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
-                .insert();
-
-        simpleDb.rollback();
-
-        long newCount = simpleDb.genSql()
-                .append("SELECT COUNT(*)")
-                .append("FROM article")
-                .selectLong();
-
-        assertThat(newCount).isEqualTo(oldCount);
-    }
-
-    @Test
-    @DisplayName("commit")
-    public void t019() {
-        // SimpleDB에서 SQL 객체를 생성합니다.
-        long oldCount = simpleDb.genSql()
-                .append("SELECT COUNT(*)")
-                .append("FROM article")
-                .selectLong();
-
-        // 트랜잭션을 시작합니다.
-        simpleDb.startTransaction();
-
-        simpleDb.genSql()
-                .append("INSERT INTO article ")
-                .append("(createdDate, modifiedDate, title, body)")
-                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
-                .insert();
-
-        simpleDb.commit();
-
-        long newCount = simpleDb.genSql()
-                .append("SELECT COUNT(*)")
-                .append("FROM article")
-                .selectLong();
-
-        assertThat(newCount).isEqualTo(oldCount + 1);
-    }
+//    @Test
+//    @DisplayName("delete")
+//    public void t003() {
+//        Sql sql = simpleDb.genSql();
+//
+//        // id가 0, 1, 3인 글 삭제
+//        // id가 0인 글은 없으니, 실제로는 2개의 글이 삭제됨
+//        /*
+//        == rawSql ==
+//        DELETE FROM article
+//        WHERE id IN ('0', '1', '3')
+//        */
+//        sql.append("DELETE")
+//                .append("FROM article")
+//                .append("WHERE id IN (?, ?, ?)", 0, 1, 3);
+//
+//        // 삭제된 row 개수
+//        int affectedRowsCount = sql.delete();
+//
+//        assertThat(affectedRowsCount).isEqualTo(2);
+//    }
+//
+//    @Test
+//    @DisplayName("selectRows")
+//    public void t004() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT *
+//        FROM article
+//        ORDER BY id ASC
+//        LIMIT 3
+//        */
+//        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
+//        List<Map<String, Object>> articleRows = sql.selectRows();
+//
+//        IntStream.range(0, articleRows.size()).forEach(i -> {
+//            long id = i + 1;
+//
+//            Map<String, Object> articleRow = articleRows.get(i);
+//
+//            assertThat(articleRow.get("id")).isEqualTo(id);
+//            assertThat(articleRow.get("title")).isEqualTo("제목%d".formatted(id));
+//            assertThat(articleRow.get("body")).isEqualTo("내용%d".formatted(id));
+//            assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
+//            assertThat(articleRow.get("createdDate")).isNotNull();
+//            assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
+//            assertThat(articleRow.get("modifiedDate")).isNotNull();
+//            assertThat(articleRow.get("isBlind")).isEqualTo(false);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("selectRow")
+//    public void t005() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT *
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT * FROM article WHERE id = 1");
+//        Map<String, Object> articleRow = sql.selectRow();
+//
+//        assertThat(articleRow.get("id")).isEqualTo(1L);
+//        assertThat(articleRow.get("title")).isEqualTo("제목1");
+//        assertThat(articleRow.get("body")).isEqualTo("내용1");
+//        assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
+//        assertThat(articleRow.get("createdDate")).isNotNull();
+//        assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
+//        assertThat(articleRow.get("modifiedDate")).isNotNull();
+//        assertThat(articleRow.get("isBlind")).isEqualTo(false);
+//    }
+//
+//    @Test
+//    @DisplayName("selectDatetime")
+//    public void t006() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT NOW()
+//        */
+//        sql.append("SELECT NOW()");
+//
+//        LocalDateTime datetime = sql.selectDatetime();
+//
+//        long diff = ChronoUnit.SECONDS.between(datetime, LocalDateTime.now());
+//
+//        assertThat(diff).isLessThanOrEqualTo(1L);
+//    }
+//
+//    @Test
+//    @DisplayName("selectLong")
+//    public void t007() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT id
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT id")
+//                .append("FROM article")
+//                .append("WHERE id = 1");
+//
+//        Long id = sql.selectLong();
+//
+//        assertThat(id).isEqualTo(1);
+//    }
+//
+//    @Test
+//    @DisplayName("selectString")
+//    public void t008() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT title
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT title")
+//                .append("FROM article")
+//                .append("WHERE id = 1");
+//
+//        String title = sql.selectString();
+//
+//        assertThat(title).isEqualTo("제목1");
+//    }
+//
+//    @Test
+//    @DisplayName("selectBoolean")
+//    public void t009() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT isBlind
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT isBlind")
+//                .append("FROM article")
+//                .append("WHERE id = 1");
+//
+//        Boolean isBlind = sql.selectBoolean();
+//
+//        assertThat(isBlind).isEqualTo(false);
+//    }
+//
+//    @Test
+//    @DisplayName("selectBoolean, 2nd")
+//    public void t010() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT 1 = 1
+//        */
+//        sql.append("SELECT 1 = 1");
+//
+//        Boolean isBlind = sql.selectBoolean();
+//
+//        assertThat(isBlind).isEqualTo(true);
+//    }
+//
+//    @Test
+//    @DisplayName("selectBoolean, 3rd")
+//    public void t011() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT 1 = 0
+//        */
+//        sql.append("SELECT 1 = 0");
+//
+//        Boolean isBlind = sql.selectBoolean();
+//
+//        assertThat(isBlind).isEqualTo(false);
+//    }
+//
+//    @Test
+//    @DisplayName("select, LIKE 사용법")
+//    public void t012() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT COUNT(*)
+//        FROM article
+//        WHERE id BETWEEN '1' AND '3'
+//        AND title LIKE CONCAT('%', '제목' '%')
+//        */
+//        sql.append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .append("WHERE id BETWEEN ? AND ?", 1, 3)
+//                .append("AND title LIKE CONCAT('%', ? '%')", "제목");
+//
+//        long count = sql.selectLong();
+//
+//        assertThat(count).isEqualTo(3);
+//    }
+//
+//    @Test
+//    @DisplayName("appendIn")
+//    public void t013() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT COUNT(*)
+//        FROM article
+//        WHERE id IN ('1', '2', '3')
+//        */
+//        sql.append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .appendIn("WHERE id IN (?)", 1, 2, 3);
+//
+//        long count = sql.selectLong();
+//
+//        assertThat(count).isEqualTo(3);
+//    }
+//
+//    @Test
+//    @DisplayName("selectLongs, ORDER BY FIELD 사용법")
+//    public void t014() {
+//        Long[] ids = new Long[]{2L, 1L, 3L};
+//
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        SELECT id
+//        FROM article
+//        WHERE id IN ('2', '3', '1')
+//        ORDER BY FIELD (id, '2', '3', '1')
+//        */
+//        sql.append("SELECT id")
+//                .append("FROM article")
+//                .appendIn("WHERE id IN (?)", ids)
+//                .appendIn("ORDER BY FIELD (id, ?)", ids);
+//
+//        List<Long> foundIds = sql.selectLongs();
+//
+//        assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
+//    }
+//
+//    @Test
+//    @DisplayName("selectRows, Article")
+//    public void t015() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT *
+//        FROM article
+//        ORDER BY id ASC
+//        LIMIT 3
+//        */
+//        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
+//        List<Article> articleRows = sql.selectRows(Article.class);
+//
+//        IntStream.range(0, articleRows.size()).forEach(i -> {
+//            long id = i + 1;
+//
+//            Article article = articleRows.get(i);
+//
+//            assertThat(article.getId()).isEqualTo(id);
+//            assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
+//            assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
+//            assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
+//            assertThat(article.getCreatedDate()).isNotNull();
+//            assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
+//            assertThat(article.getModifiedDate()).isNotNull();
+//            assertThat(article.isBlind()).isEqualTo(false);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("selectRow, Article")
+//    public void t016() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT *
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT * FROM article WHERE id = 1");
+//        Article article = sql.selectRow(Article.class);
+//
+//        Long id = 1L;
+//
+//        assertThat(article.getId()).isEqualTo(id);
+//        assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
+//        assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
+//        assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
+//        assertThat(article.getCreatedDate()).isNotNull();
+//        assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
+//        assertThat(article.getModifiedDate()).isNotNull();
+//        assertThat(article.isBlind()).isEqualTo(false);
+//    }
+//
+//    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
+//    @Test
+//    @DisplayName("use in multi threading")
+//    public void t017() throws InterruptedException {
+//        // 쓰레드 풀의 크기를 정의합니다.
+//        int numberOfThreads = 10;
+//
+//        // 고정 크기의 쓰레드 풀을 생성합니다.
+//        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+//
+//        // 성공한 작업의 수를 세는 원자적 카운터를 생성합니다.
+//        AtomicInteger successCounter = new AtomicInteger(0);
+//
+//        // 동시에 실행되는 작업의 수를 세는 데 사용되는 래치를 생성합니다.
+//        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+//
+//        // 각 쓰레드에서 실행될 작업을 정의합니다.
+//        Runnable task = () -> {
+//            try {
+//                // SimpleDB에서 SQL 객체를 생성합니다.
+//                Sql sql = simpleDb.genSql();
+//
+//                // SQL 쿼리를 작성합니다.
+//                sql.append("SELECT * FROM article WHERE id = 1");
+//
+//                // 쿼리를 실행하여 결과를 Article 객체로 매핑합니다.
+//                Article article = sql.selectRow(Article.class);
+//
+//                // 기대하는 Article 객체의 ID를 정의합니다.
+//                Long id = 1L;
+//
+//                // Article 객체의 값이 기대하는 값과 일치하는지 확인하고,
+//                // 일치하는 경우 성공 카운터를 증가시킵니다.
+//                if (article.getId() == id &&
+//                        article.getTitle().equals("제목%d".formatted(id)) &&
+//                        article.getBody().equals("내용%d".formatted(id)) &&
+//                        article.getCreatedDate() != null &&
+//                        article.getModifiedDate() != null &&
+//                        !article.isBlind()) {
+//                    successCounter.incrementAndGet();
+//                }
+//            } finally {
+//                // 커넥션 종료
+//                simpleDb.close();
+//                // 작업이 완료되면 래치 카운터를 감소시킵니다.
+//                latch.countDown();
+//            }
+//        };
+//
+//        // 쓰레드 풀에서 쓰레드를 할당받아 작업을 실행합니다.
+//        for (int i = 0; i < numberOfThreads; i++) {
+//            executorService.submit(task);
+//        }
+//
+//        // 모든 작업이 완료될 때까지 대기하거나, 최대 10초 동안 대기합니다.
+//        latch.await(10, TimeUnit.SECONDS);
+//
+//        // 쓰레드 풀을 종료시킵니다.
+//        executorService.shutdown();
+//
+//        // 성공 카운터가 쓰레드 수와 동일한지 확인합니다.
+//        assertThat(successCounter.get()).isEqualTo(numberOfThreads);
+//    }
+//
+//    @Test
+//    @DisplayName("rollback")
+//    public void t018() {
+//        // SimpleDB에서 SQL 객체를 생성합니다.
+//        long oldCount = simpleDb.genSql()
+//                .append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .selectLong();
+//
+//        // 트랜잭션을 시작합니다.
+//        simpleDb.startTransaction();
+//
+//        simpleDb.genSql()
+//                .append("INSERT INTO article ")
+//                .append("(createdDate, modifiedDate, title, body)")
+//                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
+//                .insert();
+//
+//        simpleDb.rollback();
+//
+//        long newCount = simpleDb.genSql()
+//                .append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .selectLong();
+//
+//        assertThat(newCount).isEqualTo(oldCount);
+//    }
+//
+//    @Test
+//    @DisplayName("commit")
+//    public void t019() {
+//        // SimpleDB에서 SQL 객체를 생성합니다.
+//        long oldCount = simpleDb.genSql()
+//                .append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .selectLong();
+//
+//        // 트랜잭션을 시작합니다.
+//        simpleDb.startTransaction();
+//
+//        simpleDb.genSql()
+//                .append("INSERT INTO article ")
+//                .append("(createdDate, modifiedDate, title, body)")
+//                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
+//                .insert();
+//
+//        simpleDb.commit();
+//
+//        long newCount = simpleDb.genSql()
+//                .append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .selectLong();
+//
+//        assertThat(newCount).isEqualTo(oldCount + 1);
+//    }
 }

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -242,25 +242,25 @@ public class SimpleDbTest {
         assertThat(title).isEqualTo("제목1");
     }
 
-//    @Test
-//    @DisplayName("selectBoolean")
-//    public void t009() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT isBlind
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT isBlind")
-//                .append("FROM article")
-//                .append("WHERE id = 1");
-//
-//        Boolean isBlind = sql.selectBoolean();
-//
-//        assertThat(isBlind).isEqualTo(false);
-//    }
-//
+    @Test
+    @DisplayName("selectBoolean")
+    public void t009() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT isBlind
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT isBlind")
+                .append("FROM article")
+                .append("WHERE id = 1");
+
+        Boolean isBlind = sql.selectBoolean();
+
+        assertThat(isBlind).isEqualTo(false);
+    }
+
 //    @Test
 //    @DisplayName("selectBoolean, 2nd")
 //    public void t010() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -2,6 +2,9 @@ package com.back.simpleDb;
 
 import org.junit.jupiter.api.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -130,36 +133,36 @@ public class SimpleDbTest {
         assertThat(affectedRowsCount).isEqualTo(2);
     }
 
-//    @Test
-//    @DisplayName("selectRows")
-//    public void t004() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT *
-//        FROM article
-//        ORDER BY id ASC
-//        LIMIT 3
-//        */
-//        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
-//        List<Map<String, Object>> articleRows = sql.selectRows();
-//
-//        IntStream.range(0, articleRows.size()).forEach(i -> {
-//            long id = i + 1;
-//
-//            Map<String, Object> articleRow = articleRows.get(i);
-//
-//            assertThat(articleRow.get("id")).isEqualTo(id);
-//            assertThat(articleRow.get("title")).isEqualTo("제목%d".formatted(id));
-//            assertThat(articleRow.get("body")).isEqualTo("내용%d".formatted(id));
-//            assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
-//            assertThat(articleRow.get("createdDate")).isNotNull();
-//            assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
-//            assertThat(articleRow.get("modifiedDate")).isNotNull();
-//            assertThat(articleRow.get("isBlind")).isEqualTo(false);
-//        });
-//    }
-//
+    @Test
+    @DisplayName("selectRows")
+    public void t004() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT *
+        FROM article
+        ORDER BY id ASC
+        LIMIT 3
+        */
+        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
+        List<Map<String, Object>> articleRows = sql.selectRows();
+
+        IntStream.range(0, articleRows.size()).forEach(i -> {
+            long id = i + 1;
+
+            Map<String, Object> articleRow = articleRows.get(i);
+
+            assertThat(articleRow.get("id")).isEqualTo(id);
+            assertThat(articleRow.get("title")).isEqualTo("제목%d".formatted(id));
+            assertThat(articleRow.get("body")).isEqualTo("내용%d".formatted(id));
+            assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
+            assertThat(articleRow.get("createdDate")).isNotNull();
+            assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
+            assertThat(articleRow.get("modifiedDate")).isNotNull();
+            assertThat(articleRow.get("isBlind")).isEqualTo(false);
+        });
+    }
+
 //    @Test
 //    @DisplayName("selectRow")
 //    public void t005() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -291,27 +291,27 @@ public class SimpleDbTest {
         assertThat(isBlind).isEqualTo(false);
     }
 
-//    @Test
-//    @DisplayName("select, LIKE 사용법")
-//    public void t012() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT COUNT(*)
-//        FROM article
-//        WHERE id BETWEEN '1' AND '3'
-//        AND title LIKE CONCAT('%', '제목' '%')
-//        */
-//        sql.append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .append("WHERE id BETWEEN ? AND ?", 1, 3)
-//                .append("AND title LIKE CONCAT('%', ? '%')", "제목");
-//
-//        long count = sql.selectLong();
-//
-//        assertThat(count).isEqualTo(3);
-//    }
-//
+    @Test
+    @DisplayName("select, LIKE 사용법")
+    public void t012() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT COUNT(*)
+        FROM article
+        WHERE id BETWEEN '1' AND '3'
+        AND title LIKE CONCAT('%', '제목' '%')
+        */
+        sql.append("SELECT COUNT(*)")
+                .append("FROM article")
+                .append("WHERE id BETWEEN ? AND ?", 1, 3)
+                .append("AND title LIKE CONCAT('%', ? '%')", "제목");
+
+        long count = sql.selectLong();
+
+        assertThat(count).isEqualTo(3);
+    }
+
 //    @Test
 //    @DisplayName("appendIn")
 //    public void t013() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -1,5 +1,6 @@
 package com.back.simpleDb;
 
+import com.back.domain.Article;
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
@@ -354,36 +355,36 @@ public class SimpleDbTest {
         assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
     }
 
-//    @Test
-//    @DisplayName("selectRows, Article")
-//    public void t015() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT *
-//        FROM article
-//        ORDER BY id ASC
-//        LIMIT 3
-//        */
-//        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
-//        List<Article> articleRows = sql.selectRows(Article.class);
-//
-//        IntStream.range(0, articleRows.size()).forEach(i -> {
-//            long id = i + 1;
-//
-//            Article article = articleRows.get(i);
-//
-//            assertThat(article.getId()).isEqualTo(id);
-//            assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
-//            assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
-//            assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
-//            assertThat(article.getCreatedDate()).isNotNull();
-//            assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
-//            assertThat(article.getModifiedDate()).isNotNull();
-//            assertThat(article.isBlind()).isEqualTo(false);
-//        });
-//    }
-//
+    @Test
+    @DisplayName("selectRows, Article")
+    public void t015() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT *
+        FROM article
+        ORDER BY id ASC
+        LIMIT 3
+        */
+        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
+        List<Article> articleRows = sql.selectRows(Article.class);
+
+        IntStream.range(0, articleRows.size()).forEach(i -> {
+            long id = i + 1;
+
+            Article article = articleRows.get(i);
+
+            assertThat(article.getId()).isEqualTo(id);
+            assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
+            assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
+            assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
+            assertThat(article.getCreatedDate()).isNotNull();
+            assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
+            assertThat(article.getModifiedDate()).isNotNull();
+            assertThat(article.isBlind()).isEqualTo(false);
+        });
+    }
+
 //    @Test
 //    @DisplayName("selectRow, Article")
 //    public void t016() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -312,25 +312,25 @@ public class SimpleDbTest {
         assertThat(count).isEqualTo(3);
     }
 
-//    @Test
-//    @DisplayName("appendIn")
-//    public void t013() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT COUNT(*)
-//        FROM article
-//        WHERE id IN ('1', '2', '3')
-//        */
-//        sql.append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .appendIn("WHERE id IN (?)", 1, 2, 3);
-//
-//        long count = sql.selectLong();
-//
-//        assertThat(count).isEqualTo(3);
-//    }
-//
+    @Test
+    @DisplayName("appendIn")
+    public void t013() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT COUNT(*)
+        FROM article
+        WHERE id IN ('1', '2', '3')
+        */
+        sql.append("SELECT COUNT(*)")
+                .append("FROM article")
+                .appendIn("WHERE id IN (?)", 1, 2, 3);
+
+        long count = sql.selectLong();
+
+        assertThat(count).isEqualTo(3);
+    }
+
 //    @Test
 //    @DisplayName("selectLongs, ORDER BY FIELD 사용법")
 //    public void t014() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -8,6 +8,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -410,70 +415,70 @@ public class SimpleDbTest {
         assertThat(article.isBlind()).isEqualTo(false);
     }
 
-//    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
-//    @Test
-//    @DisplayName("use in multi threading")
-//    public void t017() throws InterruptedException {
-//        // 쓰레드 풀의 크기를 정의합니다.
-//        int numberOfThreads = 10;
-//
-//        // 고정 크기의 쓰레드 풀을 생성합니다.
-//        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
-//
-//        // 성공한 작업의 수를 세는 원자적 카운터를 생성합니다.
-//        AtomicInteger successCounter = new AtomicInteger(0);
-//
-//        // 동시에 실행되는 작업의 수를 세는 데 사용되는 래치를 생성합니다.
-//        CountDownLatch latch = new CountDownLatch(numberOfThreads);
-//
-//        // 각 쓰레드에서 실행될 작업을 정의합니다.
-//        Runnable task = () -> {
-//            try {
-//                // SimpleDB에서 SQL 객체를 생성합니다.
-//                Sql sql = simpleDb.genSql();
-//
-//                // SQL 쿼리를 작성합니다.
-//                sql.append("SELECT * FROM article WHERE id = 1");
-//
-//                // 쿼리를 실행하여 결과를 Article 객체로 매핑합니다.
-//                Article article = sql.selectRow(Article.class);
-//
-//                // 기대하는 Article 객체의 ID를 정의합니다.
-//                Long id = 1L;
-//
-//                // Article 객체의 값이 기대하는 값과 일치하는지 확인하고,
-//                // 일치하는 경우 성공 카운터를 증가시킵니다.
-//                if (article.getId() == id &&
-//                        article.getTitle().equals("제목%d".formatted(id)) &&
-//                        article.getBody().equals("내용%d".formatted(id)) &&
-//                        article.getCreatedDate() != null &&
-//                        article.getModifiedDate() != null &&
-//                        !article.isBlind()) {
-//                    successCounter.incrementAndGet();
-//                }
-//            } finally {
-//                // 커넥션 종료
-//                simpleDb.close();
-//                // 작업이 완료되면 래치 카운터를 감소시킵니다.
-//                latch.countDown();
-//            }
-//        };
-//
-//        // 쓰레드 풀에서 쓰레드를 할당받아 작업을 실행합니다.
-//        for (int i = 0; i < numberOfThreads; i++) {
-//            executorService.submit(task);
-//        }
-//
-//        // 모든 작업이 완료될 때까지 대기하거나, 최대 10초 동안 대기합니다.
-//        latch.await(10, TimeUnit.SECONDS);
-//
-//        // 쓰레드 풀을 종료시킵니다.
-//        executorService.shutdown();
-//
-//        // 성공 카운터가 쓰레드 수와 동일한지 확인합니다.
-//        assertThat(successCounter.get()).isEqualTo(numberOfThreads);
-//    }
-//
+    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
+    @Test
+    @DisplayName("use in multi threading")
+    public void t017() throws InterruptedException {
+        // 쓰레드 풀의 크기를 정의합니다.
+        int numberOfThreads = 10;
+
+        // 고정 크기의 쓰레드 풀을 생성합니다.
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        // 성공한 작업의 수를 세는 원자적 카운터를 생성합니다.
+        AtomicInteger successCounter = new AtomicInteger(0);
+
+        // 동시에 실행되는 작업의 수를 세는 데 사용되는 래치를 생성합니다.
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        // 각 쓰레드에서 실행될 작업을 정의합니다.
+        Runnable task = () -> {
+            try {
+                // SimpleDB에서 SQL 객체를 생성합니다.
+                Sql sql = simpleDb.genSql();
+
+                // SQL 쿼리를 작성합니다.
+                sql.append("SELECT * FROM article WHERE id = 1");
+
+                // 쿼리를 실행하여 결과를 Article 객체로 매핑합니다.
+                Article article = sql.selectRow(Article.class);
+
+                // 기대하는 Article 객체의 ID를 정의합니다.
+                Long id = 1L;
+
+                // Article 객체의 값이 기대하는 값과 일치하는지 확인하고,
+                // 일치하는 경우 성공 카운터를 증가시킵니다.
+                if (article.getId() == id &&
+                        article.getTitle().equals("제목%d".formatted(id)) &&
+                        article.getBody().equals("내용%d".formatted(id)) &&
+                        article.getCreatedDate() != null &&
+                        article.getModifiedDate() != null &&
+                        !article.isBlind()) {
+                    successCounter.incrementAndGet();
+                }
+            } finally {
+                // 커넥션 종료
+                simpleDb.close();
+                // 작업이 완료되면 래치 카운터를 감소시킵니다.
+                latch.countDown();
+            }
+        };
+
+        // 쓰레드 풀에서 쓰레드를 할당받아 작업을 실행합니다.
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(task);
+        }
+
+        // 모든 작업이 완료될 때까지 대기하거나, 최대 10초 동안 대기합니다.
+        latch.await(10, TimeUnit.SECONDS);
+
+        // 쓰레드 풀을 종료시킵니다.
+        executorService.shutdown();
+
+        // 성공 카운터가 쓰레드 수와 동일한지 확인합니다.
+        assertThat(successCounter.get()).isEqualTo(numberOfThreads);
+    }
+
 //    @Test
 //    @DisplayName("rollback")
 //    public void t018() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -1,8 +1,7 @@
 package com.back.simpleDb;
 
-import com.back.Article;
+import com.back.domain.Article;
 import org.junit.jupiter.api.*;
-import org.springframework.test.context.jdbc.Sql;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -3,6 +3,7 @@ package com.back.simpleDb;
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -186,23 +187,23 @@ public class SimpleDbTest {
         assertThat(articleRow.get("isBlind")).isEqualTo(false);
     }
 
-//    @Test
-//    @DisplayName("selectDatetime")
-//    public void t006() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT NOW()
-//        */
-//        sql.append("SELECT NOW()");
-//
-//        LocalDateTime datetime = sql.selectDatetime();
-//
-//        long diff = ChronoUnit.SECONDS.between(datetime, LocalDateTime.now());
-//
-//        assertThat(diff).isLessThanOrEqualTo(1L);
-//    }
-//
+    @Test
+    @DisplayName("selectDatetime")
+    public void t006() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT NOW()
+        */
+        sql.append("SELECT NOW()");
+
+        LocalDateTime datetime = sql.selectDatetime();
+
+        long diff = ChronoUnit.SECONDS.between(datetime, LocalDateTime.now());
+
+        assertThat(diff).isLessThanOrEqualTo(1L);
+    }
+
 //    @Test
 //    @DisplayName("selectLong")
 //    public void t007() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -223,25 +223,25 @@ public class SimpleDbTest {
         assertThat(id).isEqualTo(1);
     }
 
-//    @Test
-//    @DisplayName("selectString")
-//    public void t008() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT title
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT title")
-//                .append("FROM article")
-//                .append("WHERE id = 1");
-//
-//        String title = sql.selectString();
-//
-//        assertThat(title).isEqualTo("제목1");
-//    }
-//
+    @Test
+    @DisplayName("selectString")
+    public void t008() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT title
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT title")
+                .append("FROM article")
+                .append("WHERE id = 1");
+
+        String title = sql.selectString();
+
+        assertThat(title).isEqualTo("제목1");
+    }
+
 //    @Test
 //    @DisplayName("selectBoolean")
 //    public void t009() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -385,31 +385,31 @@ public class SimpleDbTest {
         });
     }
 
-//    @Test
-//    @DisplayName("selectRow, Article")
-//    public void t016() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT *
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT * FROM article WHERE id = 1");
-//        Article article = sql.selectRow(Article.class);
-//
-//        Long id = 1L;
-//
-//        assertThat(article.getId()).isEqualTo(id);
-//        assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
-//        assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
-//        assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
-//        assertThat(article.getCreatedDate()).isNotNull();
-//        assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
-//        assertThat(article.getModifiedDate()).isNotNull();
-//        assertThat(article.isBlind()).isEqualTo(false);
-//    }
-//
+    @Test
+    @DisplayName("selectRow, Article")
+    public void t016() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT *
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT * FROM article WHERE id = 1");
+        Article article = sql.selectRow(Article.class);
+
+        Long id = 1L;
+
+        assertThat(article.getId()).isEqualTo(id);
+        assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
+        assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
+        assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
+        assertThat(article.getCreatedDate()).isNotNull();
+        assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
+        assertThat(article.getModifiedDate()).isNotNull();
+        assertThat(article.isBlind()).isEqualTo(false);
+    }
+
 //    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
 //    @Test
 //    @DisplayName("use in multi threading")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -204,25 +204,25 @@ public class SimpleDbTest {
         assertThat(diff).isLessThanOrEqualTo(1L);
     }
 
-//    @Test
-//    @DisplayName("selectLong")
-//    public void t007() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT id
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT id")
-//                .append("FROM article")
-//                .append("WHERE id = 1");
-//
-//        Long id = sql.selectLong();
-//
-//        assertThat(id).isEqualTo(1);
-//    }
-//
+    @Test
+    @DisplayName("selectLong")
+    public void t007() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT id
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT id")
+                .append("FROM article")
+                .append("WHERE id = 1");
+
+        Long id = sql.selectLong();
+
+        assertThat(id).isEqualTo(1);
+    }
+
 //    @Test
 //    @DisplayName("selectString")
 //    public void t008() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -331,28 +332,28 @@ public class SimpleDbTest {
         assertThat(count).isEqualTo(3);
     }
 
-//    @Test
-//    @DisplayName("selectLongs, ORDER BY FIELD 사용법")
-//    public void t014() {
-//        Long[] ids = new Long[]{2L, 1L, 3L};
-//
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        SELECT id
-//        FROM article
-//        WHERE id IN ('2', '3', '1')
-//        ORDER BY FIELD (id, '2', '3', '1')
-//        */
-//        sql.append("SELECT id")
-//                .append("FROM article")
-//                .appendIn("WHERE id IN (?)", ids)
-//                .appendIn("ORDER BY FIELD (id, ?)", ids);
-//
-//        List<Long> foundIds = sql.selectLongs();
-//
-//        assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
-//    }
-//
+    @Test
+    @DisplayName("selectLongs, ORDER BY FIELD 사용법")
+    public void t014() {
+        Long[] ids = new Long[]{2L, 1L, 3L};
+
+        Sql sql = simpleDb.genSql();
+        /*
+        SELECT id
+        FROM article
+        WHERE id IN ('2', '3', '1')
+        ORDER BY FIELD (id, '2', '3', '1')
+        */
+        sql.append("SELECT id")
+                .append("FROM article")
+                .appendIn("WHERE id IN (?)", ids)
+                .appendIn("ORDER BY FIELD (id, ?)", ids);
+
+        List<Long> foundIds = sql.selectLongs();
+
+        assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
+    }
+
 //    @Test
 //    @DisplayName("selectRows, Article")
 //    public void t015() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -261,21 +261,21 @@ public class SimpleDbTest {
         assertThat(isBlind).isEqualTo(false);
     }
 
-//    @Test
-//    @DisplayName("selectBoolean, 2nd")
-//    public void t010() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT 1 = 1
-//        */
-//        sql.append("SELECT 1 = 1");
-//
-//        Boolean isBlind = sql.selectBoolean();
-//
-//        assertThat(isBlind).isEqualTo(true);
-//    }
-//
+    @Test
+    @DisplayName("selectBoolean, 2nd")
+    public void t010() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT 1 = 1
+        */
+        sql.append("SELECT 1 = 1");
+
+        Boolean isBlind = sql.selectBoolean();
+
+        assertThat(isBlind).isEqualTo(true);
+    }
+
 //    @Test
 //    @DisplayName("selectBoolean, 3rd")
 //    public void t011() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -163,29 +163,29 @@ public class SimpleDbTest {
         });
     }
 
-//    @Test
-//    @DisplayName("selectRow")
-//    public void t005() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT *
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT * FROM article WHERE id = 1");
-//        Map<String, Object> articleRow = sql.selectRow();
-//
-//        assertThat(articleRow.get("id")).isEqualTo(1L);
-//        assertThat(articleRow.get("title")).isEqualTo("제목1");
-//        assertThat(articleRow.get("body")).isEqualTo("내용1");
-//        assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
-//        assertThat(articleRow.get("createdDate")).isNotNull();
-//        assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
-//        assertThat(articleRow.get("modifiedDate")).isNotNull();
-//        assertThat(articleRow.get("isBlind")).isEqualTo(false);
-//    }
-//
+    @Test
+    @DisplayName("selectRow")
+    public void t005() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT *
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT * FROM article WHERE id = 1");
+        Map<String, Object> articleRow = sql.selectRow();
+
+        assertThat(articleRow.get("id")).isEqualTo(1L);
+        assertThat(articleRow.get("title")).isEqualTo("제목1");
+        assertThat(articleRow.get("body")).isEqualTo("내용1");
+        assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
+        assertThat(articleRow.get("createdDate")).isNotNull();
+        assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
+        assertThat(articleRow.get("modifiedDate")).isNotNull();
+        assertThat(articleRow.get("isBlind")).isEqualTo(false);
+    }
+
 //    @Test
 //    @DisplayName("selectDatetime")
 //    public void t006() {


### PR DESCRIPTION
# SimpleDb 과제 PR 설명

## 작업 요약

이번 작업에서는 `SimpleDb`와 `Sql` 클래스를 확장하여 기본적인 SQL 실행, 조회 결과 매핑, 단일 값 조회, 리스트 조회, 객체 매핑, 트랜잭션 처리를 구현했다.

주요 구현 범위는 다음과 같다.

- `append()`를 통한 SQL 조각 누적 및 파라미터 저장
- `insert()`, `update()`, `delete()` 실행
- `selectRows()`, `selectRow()`를 통한 조회 결과 Map 변환
- `selectLong()`, `selectString()`, `selectBoolean()`, `selectDatetime()` 구현
- `appendIn()`을 통한 `IN (?, ?, ?)` 형태의 동적 placeholder 처리
- `selectLongs()`를 통한 여러 Long 결과 조회
- `selectRows(Class<T>)`, `selectRow(Class<T>)` 객체 매핑
- `startTransaction()`, `rollback()`, `commit()` 트랜잭션 처리
- 반복되는 파라미터 바인딩과 첫 번째 컬럼 값 추출 로직 리팩토링

## 주요 로직

### SQL과 파라미터 누적

`append()`는 SQL 문자열을 `StringBuilder`에 누적하고, `?`에 들어갈 값들은 `params` 리스트에 순서대로 저장한다.

```java
sqlBuilder.append(sql).append(" ");
this.params.add(param);
```

이후 `PreparedStatement`를 만들 때 저장된 파라미터를 순서대로 바인딩한다.

### 파라미터 바인딩 리팩토링

`insert()`, `executeUpdate()`, `selectRows()`에서 반복되던 바인딩 로직을 `bindParams()`로 분리했다.

```java
private void bindParams(PreparedStatement ps) throws Exception {
    for (int i = 0; i < params.size(); i++) {
        ps.setObject(i + 1, params.get(i));
    }
}
```

Java 배열/리스트 인덱스는 0부터 시작하지만, JDBC placeholder 인덱스는 1부터 시작하기 때문에 `i + 1`을 사용했다.

### 조회 결과를 Map으로 변환

`selectRows()`는 `ResultSet`을 읽어 각 row를 `Map<String, Object>`로 변환한다.

- key: 컬럼명
- value: 컬럼 값

```java
String columnName = metaData.getColumnLabel(i);
Object value = rs.getObject(i);
row.put(columnName, value);
```

`LinkedHashMap`을 사용하여 컬럼 순서를 유지했다.

### 첫 번째 컬럼 값 추출

`selectLong()`, `selectString()`, `selectBoolean()`처럼 단일 값을 조회하는 메서드는 조회된 row의 첫 번째 value만 필요하다.

```java
private Object getFirstValue(Map<String, Object> row) {
    return row.values().iterator().next();
}
```

`row.values()`는 Map의 value만 모은 컬렉션이고, `iterator().next()`는 그중 첫 번째 값을 꺼낸다.

### Boolean 처리

`SELECT isBlind`처럼 DB 드라이버가 Boolean으로 반환하는 경우와, `SELECT 1 = 1`처럼 MySQL이 `1` 또는 `0` 숫자로 반환하는 경우를 모두 처리했다.

```java
if (value instanceof Boolean) {
    return (Boolean) value;
}

return ((Number) value).intValue() == 1;
```

`1`이면 `true`, `0`이면 `false`로 변환된다.

### appendIn 처리

`appendIn("WHERE id IN (?)", 1, 2, 3)` 호출 시 `?` 하나를 파라미터 개수에 맞게 `?, ?, ?`로 늘린다.

```java
String questionMarks = "?";

for (int i = 1; i < params.length; i++) {
    questionMarks += ", ?";
}

sql = sql.replace("?", questionMarks);
```

이 결과 최종 SQL은 다음과 같은 형태가 된다.

```sql
WHERE id IN (?, ?, ?)
```

### 객체 매핑

`selectRows(Article.class)`와 `selectRow(Article.class)`는 조회 결과 Map을 객체로 변환한다.

공통 변환 로직은 `mapToObject()`로 분리했다.

```java
private <T> T mapToObject(Map<String, Object> row, Class<T> clazz) {
    try {
        T obj = clazz.getDeclaredConstructor().newInstance();

        String[] columnNames = row.keySet().toArray(new String[0]);

        for (int i = 0; i < columnNames.length; i++) {
            String columnName = columnNames[i];
            Object value = row.get(columnName);

            Field field = clazz.getDeclaredField(columnName);
            field.setAccessible(true);
            field.set(obj, value);
        }

        return obj;
    } catch (Exception e) {
        throw new RuntimeException(e);
    }
}
```

DB 컬럼명과 Java 필드명이 같다는 전제에서 동작한다. 예를 들어 `title` 컬럼은 `Article`의 `title` 필드에 매핑된다.

### 트랜잭션 처리

`startTransaction()`에서 `autoCommit`을 끄고, `rollback()` 또는 `commit()` 이후 다시 `autoCommit`을 켠다.

```java
getConnection().setAutoCommit(false);
getConnection().rollback();
getConnection().setAutoCommit(true);
```

같은 스레드에서 같은 커넥션을 사용할 수 있도록 `ThreadLocal<Connection>`을 사용한다.

## 테스트별 이해한 내용

### selectLong

`SELECT id`나 `SELECT COUNT(*)`처럼 결과가 row 1개, column 1개인 경우 첫 번째 값을 꺼내 `Long`으로 반환한다.

`COUNT(*)`는 여러 row를 반환하는 것이 아니라, 조건에 맞는 row 개수를 숫자 하나로 반환한다.

### selectBoolean

`SELECT isBlind`는 Boolean 값으로 올 수 있고, `SELECT 1 = 1`은 MySQL에서 숫자 `1`로 올 수 있다.

그래서 Boolean이면 그대로 반환하고, 숫자면 `1`과 비교하여 true/false를 반환하도록 처리했다.

### selectLongs

`SELECT id FROM article ...`처럼 여러 row가 반환되는 경우, 각 row의 첫 번째 컬럼 값을 꺼내 `List<Long>`으로 만든다.

정렬은 Java 코드가 아니라 SQL의 `ORDER BY FIELD(...)`가 담당하고, `selectLongs()`는 DB가 반환한 순서대로 값을 담는다.

### selectRows(Class<T>) / selectRow(Class<T>)

처음에는 `Article` 전용 setter로 값을 넣는 방식도 고려했지만, `Class<T>`를 받는 메서드 구조상 특정 클래스에만 의존하면 확장성이 떨어진다.

최종적으로는 리플렉션을 사용하여 컬럼명과 필드명을 매칭하는 방식으로 정리했다.

## 리팩토링 내용

- `bindParams()`를 만들어 PreparedStatement 파라미터 바인딩 중복 제거
- `getFirstValue()`를 만들어 첫 번째 컬럼 값 추출 로직 중복 제거
- `mapToObject()`를 만들어 Map을 객체로 변환하는 로직 분리
- `selectRow(Class<T>)`에서 `mapToObject()`를 재사용하도록 정리
- 의미 없이 호출되던 `getFirstValue(row);` 제거
- 향상된 for문 대신 인덱스 기반 반복문 사용

## 회고

이번 과제에서 가장 헷갈렸던 부분은 `ResultSet`을 Java 자료구조로 바꾸는 흐름이었다.

처음에는 `row.values().iterator().next()`가 "값을 계속 꺼내는 반복 로직"처럼 느껴졌지만, 실제로는 현재 row 안에서 첫 번째 컬럼 값을 하나만 꺼내는 코드라는 것을 이해했다.

또한 `SELECT COUNT(*)`는 데이터 여러 개를 반환하는 것이 아니라 개수를 계산한 숫자 하나를 반환한다는 점도 정리할 수 있었다.

`selectBoolean()`에서는 Java의 `boolean`과 MySQL의 `1/0` 표현이 다를 수 있다는 점을 배웠다. Java에서는 숫자 `1`이 곧바로 `true`가 아니기 때문에 직접 비교식을 통해 Boolean으로 변환해야 했다.

가장 어려웠던 부분은 리플렉션이었다. `Article` 객체에 setter로 직접 값을 넣는 방식은 이해하기 쉬웠지만, `selectRows(Class<T>)`처럼 어떤 클래스가 들어올지 모르는 구조에서는 리플렉션이 필요했다.

t14~15 테스트는 리플렉션을 이해하지 못하여 AI의 도움을 받아 리팩토링시 문제를 해결했다. 리플렉션은 아직 완전히 익숙하지 않지만, 이번 과제에서는 "DB 컬럼명과 Java 필드명을 맞춰서 실행 중에 객체를 만들고 값을 넣는 도구"로 이해하고 적용했다.

## 확인 사항

- 로컬 IDE에서 테스트 통과 여부 확인 필요
- `close()`는 현재 메서드만 존재하며 실제 커넥션 종료 로직은 아직 구현하지 않음
- 리플렉션 매핑은 컬럼명과 필드명이 동일하다는 전제에서 동작함
