### PR TITLE
[AIBE6/5팀/윤하빈] SimpleDb 과제 완료

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.19.0")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.0")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/back/Article.java
+++ b/src/main/java/com/back/Article.java
@@ -14,6 +14,5 @@ public class Article {
 
     @JsonProperty("isBlind")
     private boolean isBlind;
-    // Jackson이 쓸 기본 생성자
     public Article() {}
 }

--- a/src/main/java/com/back/Article.java
+++ b/src/main/java/com/back/Article.java
@@ -1,0 +1,19 @@
+package com.back;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+public class Article {
+    private Long id;
+    private String title;
+    private String body;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+
+    @JsonProperty("isBlind")
+    private boolean isBlind;
+    // Jackson이 쓸 기본 생성자
+    public Article() {}
+}

--- a/src/main/java/com/back/simpleDb/SimpleDb.java
+++ b/src/main/java/com/back/simpleDb/SimpleDb.java
@@ -28,7 +28,9 @@ public class SimpleDb {
             if (conn == null || conn.isClosed()) {
                 conn = DriverManager.getConnection(
                         "jdbc:mysql://" + host + "/" + dbName +
-                                "?serverTimezone=Asia/Seoul",
+                                "?serverTimezone=Asia/Seoul"
+                                + "&allowPublicKeyRetrieval=true"
+                                + "&useSSL=false",
                         user, password
                 );
                 connectionHolder.set(conn);

--- a/src/main/java/com/back/simpleDb/SimpleDb.java
+++ b/src/main/java/com/back/simpleDb/SimpleDb.java
@@ -1,0 +1,92 @@
+package com.back.simpleDb;
+
+import java.sql.*;
+
+public class SimpleDb {
+    private final String host;
+    private final String user;
+    private final String password;
+    private final String dbName;
+    private boolean devMode;
+
+    private final ThreadLocal<Connection> connectionHolder = new ThreadLocal<>();
+
+    public SimpleDb(String host, String user, String password, String dbName) {
+        this.host = host;
+        this.user = user;
+        this.password = password;
+        this.dbName = dbName;
+    }
+
+    public void setDevMode(boolean devMode) {
+        this.devMode = devMode;
+    }
+
+    public Connection getConnection() {
+        try {
+            Connection conn = connectionHolder.get();
+            if (conn == null || conn.isClosed()) {
+                conn = DriverManager.getConnection(
+                        "jdbc:mysql://" + host + "/" + dbName +
+                                "?serverTimezone=Asia/Seoul",
+                        user, password
+                );
+                connectionHolder.set(conn);
+            }
+            return conn;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Sql genSql() {
+        return new Sql(getConnection(), devMode);
+    }
+
+    public void run(String sql, Object... params) {
+        Sql s = new Sql(getConnection(), devMode);
+        s.append(sql, params);
+        s.run();
+    }
+
+    public void close() {
+        Connection conn = connectionHolder.get();
+        if (conn != null) {
+            try {
+                conn.close();
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            } finally {
+                connectionHolder.remove();
+            }
+        }
+    }
+
+    public void startTransaction() {
+        try {
+            getConnection().setAutoCommit(false);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void commit() {
+        try {
+            Connection conn = getConnection();
+            conn.commit();
+            conn.setAutoCommit(true);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void rollback() {
+        try {
+            Connection conn = getConnection();
+            conn.rollback();
+            conn.setAutoCommit(true);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -24,7 +24,7 @@ public class Sql {
         if (!query.isEmpty()) query.append(" ");
         query.append(sql);
         Collections.addAll(params, args);
-        return this; // 체이닝 핵심!
+        return this;
     }
 
     private PreparedStatement buildPs() throws SQLException {
@@ -162,11 +162,8 @@ public class Sql {
             rs.next();
             Object val = rs.getObject(1);
 
-            // BIT(1) 컬럼 → byte[]로 옴
             if (val instanceof byte[] bytes) return bytes[0] != 0;
-            // 1=1, 1=0 표현식 → Boolean으로 옴
             if (val instanceof Boolean b) return b;
-            // 혹시 숫자로 오는 경우
             if (val instanceof Number n) return n.intValue() != 0;
 
             return false;
@@ -180,7 +177,8 @@ public class Sql {
                 .mapToObj(i -> "?")
                 .collect(Collectors.joining(", "));
 
-        String expandedSql = sql.replace("?", placeholders);
+        int idx = sql.indexOf('?');
+        String expandedSql = sql.substring(0, idx) + placeholders + sql.substring(idx + 1);
 
         if (!query.isEmpty()) query.append(" ");
         query.append(expandedSql);
@@ -204,13 +202,13 @@ public class Sql {
             .registerModule(new JavaTimeModule());
 
     public <T> T selectRow(Class<T> clazz) {
-        Map<String, Object> row = selectRow(); // 이미 구현한 메서드 재사용
+        Map<String, Object> row = selectRow();
         if (row == null) return null;
         return mapper.convertValue(row, clazz);
     }
 
     public <T> List<T> selectRows(Class<T> clazz) {
-        return selectRows().stream() // 이미 구현한 메서드 재사용
+        return selectRows().stream()
                 .map(row -> mapper.convertValue(row, clazz))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -63,4 +63,7 @@ public class Sql {
             throw new RuntimeException(e);
         }
     }
+    public int delete() {
+        return update();
+    }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -1,0 +1,58 @@
+package com.back.simpleDb;
+
+import java.sql.*;
+import java.util.*;
+
+public class Sql {
+    private final Connection conn;
+    private final boolean devMode;
+    private final StringBuilder query = new StringBuilder();
+    private final List<Object> params = new ArrayList<>();
+
+    public Sql(Connection conn, boolean devMode) {
+        this.conn = conn;
+        this.devMode = devMode;
+    }
+
+    public Sql append(String sql, Object... args) {
+        if (!query.isEmpty()) query.append(" ");
+        query.append(sql);
+        Collections.addAll(params, args);
+        return this; // 체이닝 핵심!
+    }
+
+    private PreparedStatement buildPs() throws SQLException {
+        String rawSql = query.toString();
+        if (devMode) {
+            System.out.println("== rawSql ==");
+            System.out.println(rawSql);
+            System.out.println("params: " + params);
+        }
+        PreparedStatement ps = conn.prepareStatement(
+                rawSql, Statement.RETURN_GENERATED_KEYS
+        );
+        for (int i = 0; i < params.size(); i++) {
+            ps.setObject(i + 1, params.get(i));
+        }
+        return ps;
+    }
+
+    public void run() {
+        try (PreparedStatement ps = buildPs()) {
+            ps.execute();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public long insert() {
+        try (PreparedStatement ps = buildPs()) {
+            ps.executeUpdate();
+            ResultSet rs = ps.getGeneratedKeys();
+            rs.next();
+            return rs.getLong(1);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -55,4 +55,12 @@ public class Sql {
             throw new RuntimeException(e);
         }
     }
+
+    public int update() {
+        try (PreparedStatement ps = buildPs()) {
+            return ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -3,6 +3,8 @@ package com.back.simpleDb;
 import java.sql.*;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class Sql {
     private final Connection conn;
@@ -165,6 +167,32 @@ public class Sql {
             if (val instanceof Number n) return n.intValue() != 0;
 
             return false;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Sql appendIn(String sql, Object... args) {
+        String placeholders = IntStream.range(0, args.length)
+                .mapToObj(i -> "?")
+                .collect(Collectors.joining(", "));
+
+        String expandedSql = sql.replace("?", placeholders);
+
+        if (!query.isEmpty()) query.append(" ");
+        query.append(expandedSql);
+        Collections.addAll(params, args);
+        return this;
+    }
+
+    public List<Long> selectLongs() {
+        try (PreparedStatement ps = buildPs();
+             ResultSet rs = ps.executeQuery()) {
+            List<Long> result = new ArrayList<>();
+            while (rs.next()) {
+                result.add(rs.getLong(1));
+            }
+            return result;
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -1,5 +1,8 @@
 package com.back.simpleDb;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import java.sql.*;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -196,6 +199,20 @@ public class Sql {
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
+    }
+    private static final ObjectMapper mapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
+    public <T> T selectRow(Class<T> clazz) {
+        Map<String, Object> row = selectRow(); // 이미 구현한 메서드 재사용
+        if (row == null) return null;
+        return mapper.convertValue(row, clazz);
+    }
+
+    public <T> List<T> selectRows(Class<T> clazz) {
+        return selectRows().stream() // 이미 구현한 메서드 재사용
+                .map(row -> mapper.convertValue(row, clazz))
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -151,5 +151,23 @@ public class Sql {
             throw new RuntimeException(e);
         }
     }
+    public Boolean selectBoolean() {
+        try (PreparedStatement ps = buildPs();
+             ResultSet rs = ps.executeQuery()) {
+            rs.next();
+            Object val = rs.getObject(1);
+
+            // BIT(1) 컬럼 → byte[]로 옴
+            if (val instanceof byte[] bytes) return bytes[0] != 0;
+            // 1=1, 1=0 표현식 → Boolean으로 옴
+            if (val instanceof Boolean b) return b;
+            // 혹시 숫자로 오는 경우
+            if (val instanceof Number n) return n.intValue() != 0;
+
+            return false;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -1,5 +1,6 @@
 package com.back.simpleDb;
 
+
 import java.sql.*;
 import java.util.*;
 
@@ -63,7 +64,60 @@ public class Sql {
             throw new RuntimeException(e);
         }
     }
+
     public int delete() {
         return update();
     }
+
+
+
+    private Map<String, Object> resultSetToMap(ResultSet rs) throws SQLException {
+        ResultSetMetaData meta = rs.getMetaData();
+        Map<String, Object> map = new LinkedHashMap<>();
+
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
+            String col = meta.getColumnName(i);
+            Object val = rs.getObject(i);
+            map.put(col, convertValue(val));
+        }
+        return map;
+    }
+
+    private Object convertValue(Object val) {
+        if (val == null) return null;
+
+        if (val instanceof Timestamp ts) {
+            return ts.toLocalDateTime();
+        }
+
+        if (val instanceof byte[] bytes) {
+            return bytes[0] != 0;
+        }
+
+        return val;
+    }
+
+    public Map<String, Object> selectRow() {
+        try (PreparedStatement ps = buildPs();
+             ResultSet rs = ps.executeQuery()) {
+            if (!rs.next()) return null;
+            return resultSetToMap(rs);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<Map<String, Object>> selectRows() {
+        try (PreparedStatement ps = buildPs();
+             ResultSet rs = ps.executeQuery()) {
+            List<Map<String, Object>> result = new ArrayList<>();
+            while (rs.next()) {
+                result.add(resultSetToMap(rs));
+            }
+            return result;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 }

--- a/src/main/java/com/back/simpleDb/Sql.java
+++ b/src/main/java/com/back/simpleDb/Sql.java
@@ -1,7 +1,7 @@
 package com.back.simpleDb;
 
-
 import java.sql.*;
+import java.time.LocalDateTime;
 import java.util.*;
 
 public class Sql {
@@ -115,6 +115,38 @@ public class Sql {
                 result.add(resultSetToMap(rs));
             }
             return result;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public LocalDateTime selectDatetime() {
+        try (PreparedStatement ps = buildPs();
+             ResultSet rs = ps.executeQuery()) {
+            rs.next();
+            Timestamp ts = rs.getTimestamp(1);
+            return ts != null ? ts.toLocalDateTime() : null;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Long selectLong() {
+        try (PreparedStatement ps = buildPs();
+             ResultSet rs = ps.executeQuery()) {
+            rs.next();
+            return rs.getLong(1);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String selectString() {
+        try (PreparedStatement ps = buildPs();
+             ResultSet rs = ps.executeQuery()) {
+            rs.next();
+            return rs.getString(1);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -1,19 +1,7 @@
 package com.back.simpleDb;
 
-import com.back.Article;
 import org.junit.jupiter.api.*;
-import org.springframework.test.context.jdbc.Sql;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -96,443 +84,444 @@ public class SimpleDbTest {
         assertThat(newId).isGreaterThan(0);
     }
 
-    @Test
-    @DisplayName("update")
-    public void t002() {
-        Sql sql = simpleDb.genSql();
 
-        // id가 0, 1, 2, 3인 글 수정
-        // id가 0인 글은 없으니, 실제로는 3개의 글이 삭제됨
-
-        /*
-        == rawSql ==
-        UPDATE article
-        SET title = '제목 new'
-        WHERE id IN ('0', '1', '2', '3')
-        */
-        sql.append("UPDATE article")
-                .append("SET title = ?", "제목 new")
-                .append("WHERE id IN (?, ?, ?, ?)", 0, 1, 2, 3);
-
-        // 수정된 row 개수
-        int affectedRowsCount = sql.update();
-
-        assertThat(affectedRowsCount).isEqualTo(3);
-    }
-
-    @Test
-    @DisplayName("delete")
-    public void t003() {
-        Sql sql = simpleDb.genSql();
-
-        // id가 0, 1, 3인 글 삭제
-        // id가 0인 글은 없으니, 실제로는 2개의 글이 삭제됨
-        /*
-        == rawSql ==
-        DELETE FROM article
-        WHERE id IN ('0', '1', '3')
-        */
-        sql.append("DELETE")
-                .append("FROM article")
-                .append("WHERE id IN (?, ?, ?)", 0, 1, 3);
-
-        // 삭제된 row 개수
-        int affectedRowsCount = sql.delete();
-
-        assertThat(affectedRowsCount).isEqualTo(2);
-    }
-
-    @Test
-    @DisplayName("selectRows")
-    public void t004() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT *
-        FROM article
-        ORDER BY id ASC
-        LIMIT 3
-        */
-        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
-        List<Map<String, Object>> articleRows = sql.selectRows();
-
-        IntStream.range(0, articleRows.size()).forEach(i -> {
-            long id = i + 1;
-
-            Map<String, Object> articleRow = articleRows.get(i);
-
-            assertThat(articleRow.get("id")).isEqualTo(id);
-            assertThat(articleRow.get("title")).isEqualTo("제목%d".formatted(id));
-            assertThat(articleRow.get("body")).isEqualTo("내용%d".formatted(id));
-            assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
-            assertThat(articleRow.get("createdDate")).isNotNull();
-            assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
-            assertThat(articleRow.get("modifiedDate")).isNotNull();
-            assertThat(articleRow.get("isBlind")).isEqualTo(false);
-        });
-    }
-
-    @Test
-    @DisplayName("selectRow")
-    public void t005() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT *
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT * FROM article WHERE id = 1");
-        Map<String, Object> articleRow = sql.selectRow();
-
-        assertThat(articleRow.get("id")).isEqualTo(1L);
-        assertThat(articleRow.get("title")).isEqualTo("제목1");
-        assertThat(articleRow.get("body")).isEqualTo("내용1");
-        assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
-        assertThat(articleRow.get("createdDate")).isNotNull();
-        assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
-        assertThat(articleRow.get("modifiedDate")).isNotNull();
-        assertThat(articleRow.get("isBlind")).isEqualTo(false);
-    }
-
-    @Test
-    @DisplayName("selectDatetime")
-    public void t006() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT NOW()
-        */
-        sql.append("SELECT NOW()");
-
-        LocalDateTime datetime = sql.selectDatetime();
-
-        long diff = ChronoUnit.SECONDS.between(datetime, LocalDateTime.now());
-
-        assertThat(diff).isLessThanOrEqualTo(1L);
-    }
-
-    @Test
-    @DisplayName("selectLong")
-    public void t007() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT id
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT id")
-                .append("FROM article")
-                .append("WHERE id = 1");
-
-        Long id = sql.selectLong();
-
-        assertThat(id).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("selectString")
-    public void t008() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT title
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT title")
-                .append("FROM article")
-                .append("WHERE id = 1");
-
-        String title = sql.selectString();
-
-        assertThat(title).isEqualTo("제목1");
-    }
-
-    @Test
-    @DisplayName("selectBoolean")
-    public void t009() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT isBlind
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT isBlind")
-                .append("FROM article")
-                .append("WHERE id = 1");
-
-        Boolean isBlind = sql.selectBoolean();
-
-        assertThat(isBlind).isEqualTo(false);
-    }
-
-    @Test
-    @DisplayName("selectBoolean, 2nd")
-    public void t010() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT 1 = 1
-        */
-        sql.append("SELECT 1 = 1");
-
-        Boolean isBlind = sql.selectBoolean();
-
-        assertThat(isBlind).isEqualTo(true);
-    }
-
-    @Test
-    @DisplayName("selectBoolean, 3rd")
-    public void t011() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT 1 = 0
-        */
-        sql.append("SELECT 1 = 0");
-
-        Boolean isBlind = sql.selectBoolean();
-
-        assertThat(isBlind).isEqualTo(false);
-    }
-
-    @Test
-    @DisplayName("select, LIKE 사용법")
-    public void t012() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT COUNT(*)
-        FROM article
-        WHERE id BETWEEN '1' AND '3'
-        AND title LIKE CONCAT('%', '제목' '%')
-        */
-        sql.append("SELECT COUNT(*)")
-                .append("FROM article")
-                .append("WHERE id BETWEEN ? AND ?", 1, 3)
-                .append("AND title LIKE CONCAT('%', ? '%')", "제목");
-
-        long count = sql.selectLong();
-
-        assertThat(count).isEqualTo(3);
-    }
-
-    @Test
-    @DisplayName("appendIn")
-    public void t013() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT COUNT(*)
-        FROM article
-        WHERE id IN ('1', '2', '3')
-        */
-        sql.append("SELECT COUNT(*)")
-                .append("FROM article")
-                .appendIn("WHERE id IN (?)", 1, 2, 3);
-
-        long count = sql.selectLong();
-
-        assertThat(count).isEqualTo(3);
-    }
-
-    @Test
-    @DisplayName("selectLongs, ORDER BY FIELD 사용법")
-    public void t014() {
-        Long[] ids = new Long[]{2L, 1L, 3L};
-
-        Sql sql = simpleDb.genSql();
-        /*
-        SELECT id
-        FROM article
-        WHERE id IN ('2', '3', '1')
-        ORDER BY FIELD (id, '2', '3', '1')
-        */
-        sql.append("SELECT id")
-                .append("FROM article")
-                .appendIn("WHERE id IN (?)", ids)
-                .appendIn("ORDER BY FIELD (id, ?)", ids);
-
-        List<Long> foundIds = sql.selectLongs();
-
-        assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
-    }
-
-    @Test
-    @DisplayName("selectRows, Article")
-    public void t015() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT *
-        FROM article
-        ORDER BY id ASC
-        LIMIT 3
-        */
-        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
-        List<Article> articleRows = sql.selectRows(Article.class);
-
-        IntStream.range(0, articleRows.size()).forEach(i -> {
-            long id = i + 1;
-
-            Article article = articleRows.get(i);
-
-            assertThat(article.getId()).isEqualTo(id);
-            assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
-            assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
-            assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
-            assertThat(article.getCreatedDate()).isNotNull();
-            assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
-            assertThat(article.getModifiedDate()).isNotNull();
-            assertThat(article.isBlind()).isEqualTo(false);
-        });
-    }
-
-    @Test
-    @DisplayName("selectRow, Article")
-    public void t016() {
-        Sql sql = simpleDb.genSql();
-        /*
-        == rawSql ==
-        SELECT *
-        FROM article
-        WHERE id = 1
-        */
-        sql.append("SELECT * FROM article WHERE id = 1");
-        Article article = sql.selectRow(Article.class);
-
-        Long id = 1L;
-
-        assertThat(article.getId()).isEqualTo(id);
-        assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
-        assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
-        assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
-        assertThat(article.getCreatedDate()).isNotNull();
-        assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
-        assertThat(article.getModifiedDate()).isNotNull();
-        assertThat(article.isBlind()).isEqualTo(false);
-    }
-
-    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
-    @Test
-    @DisplayName("use in multi threading")
-    public void t017() throws InterruptedException {
-        // 쓰레드 풀의 크기를 정의합니다.
-        int numberOfThreads = 10;
-
-        // 고정 크기의 쓰레드 풀을 생성합니다.
-        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
-
-        // 성공한 작업의 수를 세는 원자적 카운터를 생성합니다.
-        AtomicInteger successCounter = new AtomicInteger(0);
-
-        // 동시에 실행되는 작업의 수를 세는 데 사용되는 래치를 생성합니다.
-        CountDownLatch latch = new CountDownLatch(numberOfThreads);
-
-        // 각 쓰레드에서 실행될 작업을 정의합니다.
-        Runnable task = () -> {
-            try {
-                // SimpleDB에서 SQL 객체를 생성합니다.
-                Sql sql = simpleDb.genSql();
-
-                // SQL 쿼리를 작성합니다.
-                sql.append("SELECT * FROM article WHERE id = 1");
-
-                // 쿼리를 실행하여 결과를 Article 객체로 매핑합니다.
-                Article article = sql.selectRow(Article.class);
-
-                // 기대하는 Article 객체의 ID를 정의합니다.
-                Long id = 1L;
-
-                // Article 객체의 값이 기대하는 값과 일치하는지 확인하고,
-                // 일치하는 경우 성공 카운터를 증가시킵니다.
-                if (article.getId() == id &&
-                        article.getTitle().equals("제목%d".formatted(id)) &&
-                        article.getBody().equals("내용%d".formatted(id)) &&
-                        article.getCreatedDate() != null &&
-                        article.getModifiedDate() != null &&
-                        !article.isBlind()) {
-                    successCounter.incrementAndGet();
-                }
-            } finally {
-                // 커넥션 종료
-                simpleDb.close();
-                // 작업이 완료되면 래치 카운터를 감소시킵니다.
-                latch.countDown();
-            }
-        };
-
-        // 쓰레드 풀에서 쓰레드를 할당받아 작업을 실행합니다.
-        for (int i = 0; i < numberOfThreads; i++) {
-            executorService.submit(task);
-        }
-
-        // 모든 작업이 완료될 때까지 대기하거나, 최대 10초 동안 대기합니다.
-        latch.await(10, TimeUnit.SECONDS);
-
-        // 쓰레드 풀을 종료시킵니다.
-        executorService.shutdown();
-
-        // 성공 카운터가 쓰레드 수와 동일한지 확인합니다.
-        assertThat(successCounter.get()).isEqualTo(numberOfThreads);
-    }
-
-    @Test
-    @DisplayName("rollback")
-    public void t018() {
-        // SimpleDB에서 SQL 객체를 생성합니다.
-        long oldCount = simpleDb.genSql()
-                .append("SELECT COUNT(*)")
-                .append("FROM article")
-                .selectLong();
-
-        // 트랜잭션을 시작합니다.
-        simpleDb.startTransaction();
-
-        simpleDb.genSql()
-                .append("INSERT INTO article ")
-                .append("(createdDate, modifiedDate, title, body)")
-                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
-                .insert();
-
-        simpleDb.rollback();
-
-        long newCount = simpleDb.genSql()
-                .append("SELECT COUNT(*)")
-                .append("FROM article")
-                .selectLong();
-
-        assertThat(newCount).isEqualTo(oldCount);
-    }
-
-    @Test
-    @DisplayName("commit")
-    public void t019() {
-        // SimpleDB에서 SQL 객체를 생성합니다.
-        long oldCount = simpleDb.genSql()
-                .append("SELECT COUNT(*)")
-                .append("FROM article")
-                .selectLong();
-
-        // 트랜잭션을 시작합니다.
-        simpleDb.startTransaction();
-
-        simpleDb.genSql()
-                .append("INSERT INTO article ")
-                .append("(createdDate, modifiedDate, title, body)")
-                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
-                .insert();
-
-        simpleDb.commit();
-
-        long newCount = simpleDb.genSql()
-                .append("SELECT COUNT(*)")
-                .append("FROM article")
-                .selectLong();
-
-        assertThat(newCount).isEqualTo(oldCount + 1);
-    }
+//    @Test
+//    @DisplayName("update")
+//    public void t002() {
+//        Sql sql = simpleDb.genSql();
+//
+//        // id가 0, 1, 2, 3인 글 수정
+//        // id가 0인 글은 없으니, 실제로는 3개의 글이 삭제됨
+//
+//        /*
+//        == rawSql ==
+//        UPDATE article
+//        SET title = '제목 new'
+//        WHERE id IN ('0', '1', '2', '3')
+//        */
+//        sql.append("UPDATE article")
+//                .append("SET title = ?", "제목 new")
+//                .append("WHERE id IN (?, ?, ?, ?)", 0, 1, 2, 3);
+//
+//        // 수정된 row 개수
+//        int affectedRowsCount = sql.update();
+//
+//        assertThat(affectedRowsCount).isEqualTo(3);
+//    }
+//
+//    @Test
+//    @DisplayName("delete")
+//    public void t003() {
+//        Sql sql = simpleDb.genSql();
+//
+//        // id가 0, 1, 3인 글 삭제
+//        // id가 0인 글은 없으니, 실제로는 2개의 글이 삭제됨
+//        /*
+//        == rawSql ==
+//        DELETE FROM article
+//        WHERE id IN ('0', '1', '3')
+//        */
+//        sql.append("DELETE")
+//                .append("FROM article")
+//                .append("WHERE id IN (?, ?, ?)", 0, 1, 3);
+//
+//        // 삭제된 row 개수
+//        int affectedRowsCount = sql.delete();
+//
+//        assertThat(affectedRowsCount).isEqualTo(2);
+//    }
+//
+//    @Test
+//    @DisplayName("selectRows")
+//    public void t004() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT *
+//        FROM article
+//        ORDER BY id ASC
+//        LIMIT 3
+//        */
+//        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
+//        List<Map<String, Object>> articleRows = sql.selectRows();
+//
+//        IntStream.range(0, articleRows.size()).forEach(i -> {
+//            long id = i + 1;
+//
+//            Map<String, Object> articleRow = articleRows.get(i);
+//
+//            assertThat(articleRow.get("id")).isEqualTo(id);
+//            assertThat(articleRow.get("title")).isEqualTo("제목%d".formatted(id));
+//            assertThat(articleRow.get("body")).isEqualTo("내용%d".formatted(id));
+//            assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
+//            assertThat(articleRow.get("createdDate")).isNotNull();
+//            assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
+//            assertThat(articleRow.get("modifiedDate")).isNotNull();
+//            assertThat(articleRow.get("isBlind")).isEqualTo(false);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("selectRow")
+//    public void t005() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT *
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT * FROM article WHERE id = 1");
+//        Map<String, Object> articleRow = sql.selectRow();
+//
+//        assertThat(articleRow.get("id")).isEqualTo(1L);
+//        assertThat(articleRow.get("title")).isEqualTo("제목1");
+//        assertThat(articleRow.get("body")).isEqualTo("내용1");
+//        assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
+//        assertThat(articleRow.get("createdDate")).isNotNull();
+//        assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
+//        assertThat(articleRow.get("modifiedDate")).isNotNull();
+//        assertThat(articleRow.get("isBlind")).isEqualTo(false);
+//    }
+//
+//    @Test
+//    @DisplayName("selectDatetime")
+//    public void t006() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT NOW()
+//        */
+//        sql.append("SELECT NOW()");
+//
+//        LocalDateTime datetime = sql.selectDatetime();
+//
+//        long diff = ChronoUnit.SECONDS.between(datetime, LocalDateTime.now());
+//
+//        assertThat(diff).isLessThanOrEqualTo(1L);
+//    }
+//
+//    @Test
+//    @DisplayName("selectLong")
+//    public void t007() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT id
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT id")
+//                .append("FROM article")
+//                .append("WHERE id = 1");
+//
+//        Long id = sql.selectLong();
+//
+//        assertThat(id).isEqualTo(1);
+//    }
+//
+//    @Test
+//    @DisplayName("selectString")
+//    public void t008() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT title
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT title")
+//                .append("FROM article")
+//                .append("WHERE id = 1");
+//
+//        String title = sql.selectString();
+//
+//        assertThat(title).isEqualTo("제목1");
+//    }
+//
+//    @Test
+//    @DisplayName("selectBoolean")
+//    public void t009() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT isBlind
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT isBlind")
+//                .append("FROM article")
+//                .append("WHERE id = 1");
+//
+//        Boolean isBlind = sql.selectBoolean();
+//
+//        assertThat(isBlind).isEqualTo(false);
+//    }
+//
+//    @Test
+//    @DisplayName("selectBoolean, 2nd")
+//    public void t010() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT 1 = 1
+//        */
+//        sql.append("SELECT 1 = 1");
+//
+//        Boolean isBlind = sql.selectBoolean();
+//
+//        assertThat(isBlind).isEqualTo(true);
+//    }
+//
+//    @Test
+//    @DisplayName("selectBoolean, 3rd")
+//    public void t011() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT 1 = 0
+//        */
+//        sql.append("SELECT 1 = 0");
+//
+//        Boolean isBlind = sql.selectBoolean();
+//
+//        assertThat(isBlind).isEqualTo(false);
+//    }
+//
+//    @Test
+//    @DisplayName("select, LIKE 사용법")
+//    public void t012() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT COUNT(*)
+//        FROM article
+//        WHERE id BETWEEN '1' AND '3'
+//        AND title LIKE CONCAT('%', '제목' '%')
+//        */
+//        sql.append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .append("WHERE id BETWEEN ? AND ?", 1, 3)
+//                .append("AND title LIKE CONCAT('%', ? '%')", "제목");
+//
+//        long count = sql.selectLong();
+//
+//        assertThat(count).isEqualTo(3);
+//    }
+//
+//    @Test
+//    @DisplayName("appendIn")
+//    public void t013() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT COUNT(*)
+//        FROM article
+//        WHERE id IN ('1', '2', '3')
+//        */
+//        sql.append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .appendIn("WHERE id IN (?)", 1, 2, 3);
+//
+//        long count = sql.selectLong();
+//
+//        assertThat(count).isEqualTo(3);
+//    }
+//
+//    @Test
+//    @DisplayName("selectLongs, ORDER BY FIELD 사용법")
+//    public void t014() {
+//        Long[] ids = new Long[]{2L, 1L, 3L};
+//
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        SELECT id
+//        FROM article
+//        WHERE id IN ('2', '3', '1')
+//        ORDER BY FIELD (id, '2', '3', '1')
+//        */
+//        sql.append("SELECT id")
+//                .append("FROM article")
+//                .appendIn("WHERE id IN (?)", ids)
+//                .appendIn("ORDER BY FIELD (id, ?)", ids);
+//
+//        List<Long> foundIds = sql.selectLongs();
+//
+//        assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
+//    }
+//
+//    @Test
+//    @DisplayName("selectRows, Article")
+//    public void t015() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT *
+//        FROM article
+//        ORDER BY id ASC
+//        LIMIT 3
+//        */
+//        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
+//        List<Article> articleRows = sql.selectRows(Article.class);
+//
+//        IntStream.range(0, articleRows.size()).forEach(i -> {
+//            long id = i + 1;
+//
+//            Article article = articleRows.get(i);
+//
+//            assertThat(article.getId()).isEqualTo(id);
+//            assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
+//            assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
+//            assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
+//            assertThat(article.getCreatedDate()).isNotNull();
+//            assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
+//            assertThat(article.getModifiedDate()).isNotNull();
+//            assertThat(article.isBlind()).isEqualTo(false);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("selectRow, Article")
+//    public void t016() {
+//        Sql sql = simpleDb.genSql();
+//        /*
+//        == rawSql ==
+//        SELECT *
+//        FROM article
+//        WHERE id = 1
+//        */
+//        sql.append("SELECT * FROM article WHERE id = 1");
+//        Article article = sql.selectRow(Article.class);
+//
+//        Long id = 1L;
+//
+//        assertThat(article.getId()).isEqualTo(id);
+//        assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
+//        assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
+//        assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
+//        assertThat(article.getCreatedDate()).isNotNull();
+//        assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
+//        assertThat(article.getModifiedDate()).isNotNull();
+//        assertThat(article.isBlind()).isEqualTo(false);
+//    }
+//
+//    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
+//    @Test
+//    @DisplayName("use in multi threading")
+//    public void t017() throws InterruptedException {
+//        // 쓰레드 풀의 크기를 정의합니다.
+//        int numberOfThreads = 10;
+//
+//        // 고정 크기의 쓰레드 풀을 생성합니다.
+//        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+//
+//        // 성공한 작업의 수를 세는 원자적 카운터를 생성합니다.
+//        AtomicInteger successCounter = new AtomicInteger(0);
+//
+//        // 동시에 실행되는 작업의 수를 세는 데 사용되는 래치를 생성합니다.
+//        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+//
+//        // 각 쓰레드에서 실행될 작업을 정의합니다.
+//        Runnable task = () -> {
+//            try {
+//                // SimpleDB에서 SQL 객체를 생성합니다.
+//                Sql sql = simpleDb.genSql();
+//
+//                // SQL 쿼리를 작성합니다.
+//                sql.append("SELECT * FROM article WHERE id = 1");
+//
+//                // 쿼리를 실행하여 결과를 Article 객체로 매핑합니다.
+//                Article article = sql.selectRow(Article.class);
+//
+//                // 기대하는 Article 객체의 ID를 정의합니다.
+//                Long id = 1L;
+//
+//                // Article 객체의 값이 기대하는 값과 일치하는지 확인하고,
+//                // 일치하는 경우 성공 카운터를 증가시킵니다.
+//                if (article.getId() == id &&
+//                        article.getTitle().equals("제목%d".formatted(id)) &&
+//                        article.getBody().equals("내용%d".formatted(id)) &&
+//                        article.getCreatedDate() != null &&
+//                        article.getModifiedDate() != null &&
+//                        !article.isBlind()) {
+//                    successCounter.incrementAndGet();
+//                }
+//            } finally {
+//                // 커넥션 종료
+//                simpleDb.close();
+//                // 작업이 완료되면 래치 카운터를 감소시킵니다.
+//                latch.countDown();
+//            }
+//        };
+//
+//        // 쓰레드 풀에서 쓰레드를 할당받아 작업을 실행합니다.
+//        for (int i = 0; i < numberOfThreads; i++) {
+//            executorService.submit(task);
+//        }
+//
+//        // 모든 작업이 완료될 때까지 대기하거나, 최대 10초 동안 대기합니다.
+//        latch.await(10, TimeUnit.SECONDS);
+//
+//        // 쓰레드 풀을 종료시킵니다.
+//        executorService.shutdown();
+//
+//        // 성공 카운터가 쓰레드 수와 동일한지 확인합니다.
+//        assertThat(successCounter.get()).isEqualTo(numberOfThreads);
+//    }
+//
+//    @Test
+//    @DisplayName("rollback")
+//    public void t018() {
+//        // SimpleDB에서 SQL 객체를 생성합니다.
+//        long oldCount = simpleDb.genSql()
+//                .append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .selectLong();
+//
+//        // 트랜잭션을 시작합니다.
+//        simpleDb.startTransaction();
+//
+//        simpleDb.genSql()
+//                .append("INSERT INTO article ")
+//                .append("(createdDate, modifiedDate, title, body)")
+//                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
+//                .insert();
+//
+//        simpleDb.rollback();
+//
+//        long newCount = simpleDb.genSql()
+//                .append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .selectLong();
+//
+//        assertThat(newCount).isEqualTo(oldCount);
+//    }
+//
+//    @Test
+//    @DisplayName("commit")
+//    public void t019() {
+//        // SimpleDB에서 SQL 객체를 생성합니다.
+//        long oldCount = simpleDb.genSql()
+//                .append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .selectLong();
+//
+//        // 트랜잭션을 시작합니다.
+//        simpleDb.startTransaction();
+//
+//        simpleDb.genSql()
+//                .append("INSERT INTO article ")
+//                .append("(createdDate, modifiedDate, title, body)")
+//                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
+//                .insert();
+//
+//        simpleDb.commit();
+//
+//        long newCount = simpleDb.genSql()
+//                .append("SELECT COUNT(*)")
+//                .append("FROM article")
+//                .selectLong();
+//
+//        assertThat(newCount).isEqualTo(oldCount + 1);
+//    }
 }

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -292,68 +293,68 @@ public class SimpleDbTest {
         assertThat(isBlind).isEqualTo(false);
     }
 
-//    @Test
-//    @DisplayName("select, LIKE 사용법")
-//    public void t012() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT COUNT(*)
-//        FROM article
-//        WHERE id BETWEEN '1' AND '3'
-//        AND title LIKE CONCAT('%', '제목' '%')
-//        */
-//        sql.append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .append("WHERE id BETWEEN ? AND ?", 1, 3)
-//                .append("AND title LIKE CONCAT('%', ? '%')", "제목");
-//
-//        long count = sql.selectLong();
-//
-//        assertThat(count).isEqualTo(3);
-//    }
-//
-//    @Test
-//    @DisplayName("appendIn")
-//    public void t013() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT COUNT(*)
-//        FROM article
-//        WHERE id IN ('1', '2', '3')
-//        */
-//        sql.append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .appendIn("WHERE id IN (?)", 1, 2, 3);
-//
-//        long count = sql.selectLong();
-//
-//        assertThat(count).isEqualTo(3);
-//    }
-//
-//    @Test
-//    @DisplayName("selectLongs, ORDER BY FIELD 사용법")
-//    public void t014() {
-//        Long[] ids = new Long[]{2L, 1L, 3L};
-//
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        SELECT id
-//        FROM article
-//        WHERE id IN ('2', '3', '1')
-//        ORDER BY FIELD (id, '2', '3', '1')
-//        */
-//        sql.append("SELECT id")
-//                .append("FROM article")
-//                .appendIn("WHERE id IN (?)", ids)
-//                .appendIn("ORDER BY FIELD (id, ?)", ids);
-//
-//        List<Long> foundIds = sql.selectLongs();
-//
-//        assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
-//    }
-//
+    @Test
+    @DisplayName("select, LIKE 사용법")
+    public void t012() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT COUNT(*)
+        FROM article
+        WHERE id BETWEEN '1' AND '3'
+        AND title LIKE CONCAT('%', '제목' '%')
+        */
+        sql.append("SELECT COUNT(*)")
+                .append("FROM article")
+                .append("WHERE id BETWEEN ? AND ?", 1, 3)
+                .append("AND title LIKE CONCAT('%', ? '%')", "제목");
+
+        long count = sql.selectLong();
+
+        assertThat(count).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("appendIn")
+    public void t013() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT COUNT(*)
+        FROM article
+        WHERE id IN ('1', '2', '3')
+        */
+        sql.append("SELECT COUNT(*)")
+                .append("FROM article")
+                .appendIn("WHERE id IN (?)", 1, 2, 3);
+
+        long count = sql.selectLong();
+
+        assertThat(count).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("selectLongs, ORDER BY FIELD 사용법")
+    public void t014() {
+        Long[] ids = new Long[]{2L, 1L, 3L};
+
+        Sql sql = simpleDb.genSql();
+        /*
+        SELECT id
+        FROM article
+        WHERE id IN ('2', '3', '1')
+        ORDER BY FIELD (id, '2', '3', '1')
+        */
+        sql.append("SELECT id")
+                .append("FROM article")
+                .appendIn("WHERE id IN (?)", ids)
+                .appendIn("ORDER BY FIELD (id, ?)", ids);
+
+        List<Long> foundIds = sql.selectLongs();
+
+        assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
+    }
+
 //    @Test
 //    @DisplayName("selectRows, Article")
 //    public void t015() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -109,27 +109,27 @@ public class SimpleDbTest {
         assertThat(affectedRowsCount).isEqualTo(3);
     }
 
-//    @Test
-//    @DisplayName("delete")
-//    public void t003() {
-//        Sql sql = simpleDb.genSql();
-//
-//        // id가 0, 1, 3인 글 삭제
-//        // id가 0인 글은 없으니, 실제로는 2개의 글이 삭제됨
-//        /*
-//        == rawSql ==
-//        DELETE FROM article
-//        WHERE id IN ('0', '1', '3')
-//        */
-//        sql.append("DELETE")
-//                .append("FROM article")
-//                .append("WHERE id IN (?, ?, ?)", 0, 1, 3);
-//
-//        // 삭제된 row 개수
-//        int affectedRowsCount = sql.delete();
-//
-//        assertThat(affectedRowsCount).isEqualTo(2);
-//    }
+    @Test
+    @DisplayName("delete")
+    public void t003() {
+        Sql sql = simpleDb.genSql();
+
+        // id가 0, 1, 3인 글 삭제
+        // id가 0인 글은 없으니, 실제로는 2개의 글이 삭제됨
+        /*
+        == rawSql ==
+        DELETE FROM article
+        WHERE id IN ('0', '1', '3')
+        */
+        sql.append("DELETE")
+                .append("FROM article")
+                .append("WHERE id IN (?, ?, ?)", 0, 1, 3);
+
+        // 삭제된 row 개수
+        int affectedRowsCount = sql.delete();
+
+        assertThat(affectedRowsCount).isEqualTo(2);
+    }
 //
 //    @Test
 //    @DisplayName("selectRows")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -85,30 +85,30 @@ public class SimpleDbTest {
     }
 
 
-//    @Test
-//    @DisplayName("update")
-//    public void t002() {
-//        Sql sql = simpleDb.genSql();
-//
-//        // id가 0, 1, 2, 3인 글 수정
-//        // id가 0인 글은 없으니, 실제로는 3개의 글이 삭제됨
-//
-//        /*
-//        == rawSql ==
-//        UPDATE article
-//        SET title = '제목 new'
-//        WHERE id IN ('0', '1', '2', '3')
-//        */
-//        sql.append("UPDATE article")
-//                .append("SET title = ?", "제목 new")
-//                .append("WHERE id IN (?, ?, ?, ?)", 0, 1, 2, 3);
-//
-//        // 수정된 row 개수
-//        int affectedRowsCount = sql.update();
-//
-//        assertThat(affectedRowsCount).isEqualTo(3);
-//    }
-//
+    @Test
+    @DisplayName("update")
+    public void t002() {
+        Sql sql = simpleDb.genSql();
+
+        // id가 0, 1, 2, 3인 글 수정
+        // id가 0인 글은 없으니, 실제로는 3개의 글이 삭제됨
+
+        /*
+        == rawSql ==
+        UPDATE article
+        SET title = '제목 new'
+        WHERE id IN ('0', '1', '2', '3')
+        */
+        sql.append("UPDATE article")
+                .append("SET title = ?", "제목 new")
+                .append("WHERE id IN (?, ?, ?, ?)", 0, 1, 2, 3);
+
+        // 수정된 row 개수
+        int affectedRowsCount = sql.update();
+
+        assertThat(affectedRowsCount).isEqualTo(3);
+    }
+
 //    @Test
 //    @DisplayName("delete")
 //    public void t003() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -8,6 +8,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -411,123 +416,123 @@ public class SimpleDbTest {
         assertThat(article.isBlind()).isEqualTo(false);
     }
 
-//    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
-//    @Test
-//    @DisplayName("use in multi threading")
-//    public void t017() throws InterruptedException {
-//        // 쓰레드 풀의 크기를 정의합니다.
-//        int numberOfThreads = 10;
-//
-//        // 고정 크기의 쓰레드 풀을 생성합니다.
-//        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
-//
-//        // 성공한 작업의 수를 세는 원자적 카운터를 생성합니다.
-//        AtomicInteger successCounter = new AtomicInteger(0);
-//
-//        // 동시에 실행되는 작업의 수를 세는 데 사용되는 래치를 생성합니다.
-//        CountDownLatch latch = new CountDownLatch(numberOfThreads);
-//
-//        // 각 쓰레드에서 실행될 작업을 정의합니다.
-//        Runnable task = () -> {
-//            try {
-//                // SimpleDB에서 SQL 객체를 생성합니다.
-//                Sql sql = simpleDb.genSql();
-//
-//                // SQL 쿼리를 작성합니다.
-//                sql.append("SELECT * FROM article WHERE id = 1");
-//
-//                // 쿼리를 실행하여 결과를 Article 객체로 매핑합니다.
-//                Article article = sql.selectRow(Article.class);
-//
-//                // 기대하는 Article 객체의 ID를 정의합니다.
-//                Long id = 1L;
-//
-//                // Article 객체의 값이 기대하는 값과 일치하는지 확인하고,
-//                // 일치하는 경우 성공 카운터를 증가시킵니다.
-//                if (article.getId() == id &&
-//                        article.getTitle().equals("제목%d".formatted(id)) &&
-//                        article.getBody().equals("내용%d".formatted(id)) &&
-//                        article.getCreatedDate() != null &&
-//                        article.getModifiedDate() != null &&
-//                        !article.isBlind()) {
-//                    successCounter.incrementAndGet();
-//                }
-//            } finally {
-//                // 커넥션 종료
-//                simpleDb.close();
-//                // 작업이 완료되면 래치 카운터를 감소시킵니다.
-//                latch.countDown();
-//            }
-//        };
-//
-//        // 쓰레드 풀에서 쓰레드를 할당받아 작업을 실행합니다.
-//        for (int i = 0; i < numberOfThreads; i++) {
-//            executorService.submit(task);
-//        }
-//
-//        // 모든 작업이 완료될 때까지 대기하거나, 최대 10초 동안 대기합니다.
-//        latch.await(10, TimeUnit.SECONDS);
-//
-//        // 쓰레드 풀을 종료시킵니다.
-//        executorService.shutdown();
-//
-//        // 성공 카운터가 쓰레드 수와 동일한지 확인합니다.
-//        assertThat(successCounter.get()).isEqualTo(numberOfThreads);
-//    }
-//
-//    @Test
-//    @DisplayName("rollback")
-//    public void t018() {
-//        // SimpleDB에서 SQL 객체를 생성합니다.
-//        long oldCount = simpleDb.genSql()
-//                .append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .selectLong();
-//
-//        // 트랜잭션을 시작합니다.
-//        simpleDb.startTransaction();
-//
-//        simpleDb.genSql()
-//                .append("INSERT INTO article ")
-//                .append("(createdDate, modifiedDate, title, body)")
-//                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
-//                .insert();
-//
-//        simpleDb.rollback();
-//
-//        long newCount = simpleDb.genSql()
-//                .append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .selectLong();
-//
-//        assertThat(newCount).isEqualTo(oldCount);
-//    }
-//
-//    @Test
-//    @DisplayName("commit")
-//    public void t019() {
-//        // SimpleDB에서 SQL 객체를 생성합니다.
-//        long oldCount = simpleDb.genSql()
-//                .append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .selectLong();
-//
-//        // 트랜잭션을 시작합니다.
-//        simpleDb.startTransaction();
-//
-//        simpleDb.genSql()
-//                .append("INSERT INTO article ")
-//                .append("(createdDate, modifiedDate, title, body)")
-//                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
-//                .insert();
-//
-//        simpleDb.commit();
-//
-//        long newCount = simpleDb.genSql()
-//                .append("SELECT COUNT(*)")
-//                .append("FROM article")
-//                .selectLong();
-//
-//        assertThat(newCount).isEqualTo(oldCount + 1);
-//    }
+    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
+    @Test
+    @DisplayName("use in multi threading")
+    public void t017() throws InterruptedException {
+        // 쓰레드 풀의 크기를 정의합니다.
+        int numberOfThreads = 10;
+
+        // 고정 크기의 쓰레드 풀을 생성합니다.
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        // 성공한 작업의 수를 세는 원자적 카운터를 생성합니다.
+        AtomicInteger successCounter = new AtomicInteger(0);
+
+        // 동시에 실행되는 작업의 수를 세는 데 사용되는 래치를 생성합니다.
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        // 각 쓰레드에서 실행될 작업을 정의합니다.
+        Runnable task = () -> {
+            try {
+                // SimpleDB에서 SQL 객체를 생성합니다.
+                Sql sql = simpleDb.genSql();
+
+                // SQL 쿼리를 작성합니다.
+                sql.append("SELECT * FROM article WHERE id = 1");
+
+                // 쿼리를 실행하여 결과를 Article 객체로 매핑합니다.
+                Article article = sql.selectRow(Article.class);
+
+                // 기대하는 Article 객체의 ID를 정의합니다.
+                Long id = 1L;
+
+                // Article 객체의 값이 기대하는 값과 일치하는지 확인하고,
+                // 일치하는 경우 성공 카운터를 증가시킵니다.
+                if (article.getId() == id &&
+                        article.getTitle().equals("제목%d".formatted(id)) &&
+                        article.getBody().equals("내용%d".formatted(id)) &&
+                        article.getCreatedDate() != null &&
+                        article.getModifiedDate() != null &&
+                        !article.isBlind()) {
+                    successCounter.incrementAndGet();
+                }
+            } finally {
+                // 커넥션 종료
+                simpleDb.close();
+                // 작업이 완료되면 래치 카운터를 감소시킵니다.
+                latch.countDown();
+            }
+        };
+
+        // 쓰레드 풀에서 쓰레드를 할당받아 작업을 실행합니다.
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(task);
+        }
+
+        // 모든 작업이 완료될 때까지 대기하거나, 최대 10초 동안 대기합니다.
+        latch.await(10, TimeUnit.SECONDS);
+
+        // 쓰레드 풀을 종료시킵니다.
+        executorService.shutdown();
+
+        // 성공 카운터가 쓰레드 수와 동일한지 확인합니다.
+        assertThat(successCounter.get()).isEqualTo(numberOfThreads);
+    }
+
+    @Test
+    @DisplayName("rollback")
+    public void t018() {
+        // SimpleDB에서 SQL 객체를 생성합니다.
+        long oldCount = simpleDb.genSql()
+                .append("SELECT COUNT(*)")
+                .append("FROM article")
+                .selectLong();
+
+        // 트랜잭션을 시작합니다.
+        simpleDb.startTransaction();
+
+        simpleDb.genSql()
+                .append("INSERT INTO article ")
+                .append("(createdDate, modifiedDate, title, body)")
+                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
+                .insert();
+
+        simpleDb.rollback();
+
+        long newCount = simpleDb.genSql()
+                .append("SELECT COUNT(*)")
+                .append("FROM article")
+                .selectLong();
+
+        assertThat(newCount).isEqualTo(oldCount);
+    }
+
+    @Test
+    @DisplayName("commit")
+    public void t019() {
+        // SimpleDB에서 SQL 객체를 생성합니다.
+        long oldCount = simpleDb.genSql()
+                .append("SELECT COUNT(*)")
+                .append("FROM article")
+                .selectLong();
+
+        // 트랜잭션을 시작합니다.
+        simpleDb.startTransaction();
+
+        simpleDb.genSql()
+                .append("INSERT INTO article ")
+                .append("(createdDate, modifiedDate, title, body)")
+                .appendIn("VALUES (NOW(), NOW(), ?)", "새 제목", "새 내용")
+                .insert();
+
+        simpleDb.commit();
+
+        long newCount = simpleDb.genSql()
+                .append("SELECT COUNT(*)")
+                .append("FROM article")
+                .selectLong();
+
+        assertThat(newCount).isEqualTo(oldCount + 1);
+    }
 }

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -1,5 +1,6 @@
 package com.back.simpleDb;
 
+import com.back.Article;
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
@@ -355,61 +356,61 @@ public class SimpleDbTest {
         assertThat(foundIds).isEqualTo(Arrays.stream(ids).toList());
     }
 
-//    @Test
-//    @DisplayName("selectRows, Article")
-//    public void t015() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT *
-//        FROM article
-//        ORDER BY id ASC
-//        LIMIT 3
-//        */
-//        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
-//        List<Article> articleRows = sql.selectRows(Article.class);
-//
-//        IntStream.range(0, articleRows.size()).forEach(i -> {
-//            long id = i + 1;
-//
-//            Article article = articleRows.get(i);
-//
-//            assertThat(article.getId()).isEqualTo(id);
-//            assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
-//            assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
-//            assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
-//            assertThat(article.getCreatedDate()).isNotNull();
-//            assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
-//            assertThat(article.getModifiedDate()).isNotNull();
-//            assertThat(article.isBlind()).isEqualTo(false);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("selectRow, Article")
-//    public void t016() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT *
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT * FROM article WHERE id = 1");
-//        Article article = sql.selectRow(Article.class);
-//
-//        Long id = 1L;
-//
-//        assertThat(article.getId()).isEqualTo(id);
-//        assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
-//        assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
-//        assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
-//        assertThat(article.getCreatedDate()).isNotNull();
-//        assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
-//        assertThat(article.getModifiedDate()).isNotNull();
-//        assertThat(article.isBlind()).isEqualTo(false);
-//    }
-//
+    @Test
+    @DisplayName("selectRows, Article")
+    public void t015() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT *
+        FROM article
+        ORDER BY id ASC
+        LIMIT 3
+        */
+        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
+        List<Article> articleRows = sql.selectRows(Article.class);
+
+        IntStream.range(0, articleRows.size()).forEach(i -> {
+            long id = i + 1;
+
+            Article article = articleRows.get(i);
+
+            assertThat(article.getId()).isEqualTo(id);
+            assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
+            assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
+            assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
+            assertThat(article.getCreatedDate()).isNotNull();
+            assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
+            assertThat(article.getModifiedDate()).isNotNull();
+            assertThat(article.isBlind()).isEqualTo(false);
+        });
+    }
+
+    @Test
+    @DisplayName("selectRow, Article")
+    public void t016() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT *
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT * FROM article WHERE id = 1");
+        Article article = sql.selectRow(Article.class);
+
+        Long id = 1L;
+
+        assertThat(article.getId()).isEqualTo(id);
+        assertThat(article.getTitle()).isEqualTo("제목%d".formatted(id));
+        assertThat(article.getBody()).isEqualTo("내용%d".formatted(id));
+        assertThat(article.getCreatedDate()).isInstanceOf(LocalDateTime.class);
+        assertThat(article.getCreatedDate()).isNotNull();
+        assertThat(article.getModifiedDate()).isInstanceOf(LocalDateTime.class);
+        assertThat(article.getModifiedDate()).isNotNull();
+        assertThat(article.isBlind()).isEqualTo(false);
+    }
+
 //    // 테스트 메서드를 정의하고, 테스트 이름을 지정합니다.
 //    @Test
 //    @DisplayName("use in multi threading")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -243,54 +243,54 @@ public class SimpleDbTest {
         assertThat(title).isEqualTo("제목1");
     }
 
-//    @Test
-//    @DisplayName("selectBoolean")
-//    public void t009() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT isBlind
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT isBlind")
-//                .append("FROM article")
-//                .append("WHERE id = 1");
-//
-//        Boolean isBlind = sql.selectBoolean();
-//
-//        assertThat(isBlind).isEqualTo(false);
-//    }
-//
-//    @Test
-//    @DisplayName("selectBoolean, 2nd")
-//    public void t010() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT 1 = 1
-//        */
-//        sql.append("SELECT 1 = 1");
-//
-//        Boolean isBlind = sql.selectBoolean();
-//
-//        assertThat(isBlind).isEqualTo(true);
-//    }
-//
-//    @Test
-//    @DisplayName("selectBoolean, 3rd")
-//    public void t011() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT 1 = 0
-//        */
-//        sql.append("SELECT 1 = 0");
-//
-//        Boolean isBlind = sql.selectBoolean();
-//
-//        assertThat(isBlind).isEqualTo(false);
-//    }
+    @Test
+    @DisplayName("selectBoolean")
+    public void t009() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT isBlind
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT isBlind")
+                .append("FROM article")
+                .append("WHERE id = 1");
+
+        Boolean isBlind = sql.selectBoolean();
+
+        assertThat(isBlind).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("selectBoolean, 2nd")
+    public void t010() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT 1 = 1
+        */
+        sql.append("SELECT 1 = 1");
+
+        Boolean isBlind = sql.selectBoolean();
+
+        assertThat(isBlind).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("selectBoolean, 3rd")
+    public void t011() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT 1 = 0
+        */
+        sql.append("SELECT 1 = 0");
+
+        Boolean isBlind = sql.selectBoolean();
+
+        assertThat(isBlind).isEqualTo(false);
+    }
 
 //    @Test
 //    @DisplayName("select, LIKE 사용법")

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -3,6 +3,7 @@ package com.back.simpleDb;
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -186,62 +187,62 @@ public class SimpleDbTest {
         assertThat(articleRow.get("modifiedDate")).isNotNull();
         assertThat(articleRow.get("isBlind")).isEqualTo(false);
     }
-//
-//    @Test
-//    @DisplayName("selectDatetime")
-//    public void t006() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT NOW()
-//        */
-//        sql.append("SELECT NOW()");
-//
-//        LocalDateTime datetime = sql.selectDatetime();
-//
-//        long diff = ChronoUnit.SECONDS.between(datetime, LocalDateTime.now());
-//
-//        assertThat(diff).isLessThanOrEqualTo(1L);
-//    }
-//
-//    @Test
-//    @DisplayName("selectLong")
-//    public void t007() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT id
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT id")
-//                .append("FROM article")
-//                .append("WHERE id = 1");
-//
-//        Long id = sql.selectLong();
-//
-//        assertThat(id).isEqualTo(1);
-//    }
-//
-//    @Test
-//    @DisplayName("selectString")
-//    public void t008() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT title
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT title")
-//                .append("FROM article")
-//                .append("WHERE id = 1");
-//
-//        String title = sql.selectString();
-//
-//        assertThat(title).isEqualTo("제목1");
-//    }
-//
+
+    @Test
+    @DisplayName("selectDatetime")
+    public void t006() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT NOW()
+        */
+        sql.append("SELECT NOW()");
+
+        LocalDateTime datetime = sql.selectDatetime();
+
+        long diff = ChronoUnit.SECONDS.between(datetime, LocalDateTime.now());
+
+        assertThat(diff).isLessThanOrEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("selectLong")
+    public void t007() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT id
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT id")
+                .append("FROM article")
+                .append("WHERE id = 1");
+
+        Long id = sql.selectLong();
+
+        assertThat(id).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("selectString")
+    public void t008() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT title
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT title")
+                .append("FROM article")
+                .append("WHERE id = 1");
+
+        String title = sql.selectString();
+
+        assertThat(title).isEqualTo("제목1");
+    }
+
 //    @Test
 //    @DisplayName("selectBoolean")
 //    public void t009() {
@@ -290,7 +291,7 @@ public class SimpleDbTest {
 //
 //        assertThat(isBlind).isEqualTo(false);
 //    }
-//
+
 //    @Test
 //    @DisplayName("select, LIKE 사용법")
 //    public void t012() {

--- a/src/test/java/com/back/simpleDb/SimpleDbTest.java
+++ b/src/test/java/com/back/simpleDb/SimpleDbTest.java
@@ -2,6 +2,9 @@ package com.back.simpleDb;
 
 import org.junit.jupiter.api.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -130,59 +133,59 @@ public class SimpleDbTest {
 
         assertThat(affectedRowsCount).isEqualTo(2);
     }
-//
-//    @Test
-//    @DisplayName("selectRows")
-//    public void t004() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT *
-//        FROM article
-//        ORDER BY id ASC
-//        LIMIT 3
-//        */
-//        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
-//        List<Map<String, Object>> articleRows = sql.selectRows();
-//
-//        IntStream.range(0, articleRows.size()).forEach(i -> {
-//            long id = i + 1;
-//
-//            Map<String, Object> articleRow = articleRows.get(i);
-//
-//            assertThat(articleRow.get("id")).isEqualTo(id);
-//            assertThat(articleRow.get("title")).isEqualTo("제목%d".formatted(id));
-//            assertThat(articleRow.get("body")).isEqualTo("내용%d".formatted(id));
-//            assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
-//            assertThat(articleRow.get("createdDate")).isNotNull();
-//            assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
-//            assertThat(articleRow.get("modifiedDate")).isNotNull();
-//            assertThat(articleRow.get("isBlind")).isEqualTo(false);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("selectRow")
-//    public void t005() {
-//        Sql sql = simpleDb.genSql();
-//        /*
-//        == rawSql ==
-//        SELECT *
-//        FROM article
-//        WHERE id = 1
-//        */
-//        sql.append("SELECT * FROM article WHERE id = 1");
-//        Map<String, Object> articleRow = sql.selectRow();
-//
-//        assertThat(articleRow.get("id")).isEqualTo(1L);
-//        assertThat(articleRow.get("title")).isEqualTo("제목1");
-//        assertThat(articleRow.get("body")).isEqualTo("내용1");
-//        assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
-//        assertThat(articleRow.get("createdDate")).isNotNull();
-//        assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
-//        assertThat(articleRow.get("modifiedDate")).isNotNull();
-//        assertThat(articleRow.get("isBlind")).isEqualTo(false);
-//    }
+
+    @Test
+    @DisplayName("selectRows")
+    public void t004() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT *
+        FROM article
+        ORDER BY id ASC
+        LIMIT 3
+        */
+        sql.append("SELECT * FROM article ORDER BY id ASC LIMIT 3");
+        List<Map<String, Object>> articleRows = sql.selectRows();
+
+        IntStream.range(0, articleRows.size()).forEach(i -> {
+            long id = i + 1;
+
+            Map<String, Object> articleRow = articleRows.get(i);
+
+            assertThat(articleRow.get("id")).isEqualTo(id);
+            assertThat(articleRow.get("title")).isEqualTo("제목%d".formatted(id));
+            assertThat(articleRow.get("body")).isEqualTo("내용%d".formatted(id));
+            assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
+            assertThat(articleRow.get("createdDate")).isNotNull();
+            assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
+            assertThat(articleRow.get("modifiedDate")).isNotNull();
+            assertThat(articleRow.get("isBlind")).isEqualTo(false);
+        });
+    }
+
+    @Test
+    @DisplayName("selectRow")
+    public void t005() {
+        Sql sql = simpleDb.genSql();
+        /*
+        == rawSql ==
+        SELECT *
+        FROM article
+        WHERE id = 1
+        */
+        sql.append("SELECT * FROM article WHERE id = 1");
+        Map<String, Object> articleRow = sql.selectRow();
+
+        assertThat(articleRow.get("id")).isEqualTo(1L);
+        assertThat(articleRow.get("title")).isEqualTo("제목1");
+        assertThat(articleRow.get("body")).isEqualTo("내용1");
+        assertThat(articleRow.get("createdDate")).isInstanceOf(LocalDateTime.class);
+        assertThat(articleRow.get("createdDate")).isNotNull();
+        assertThat(articleRow.get("modifiedDate")).isInstanceOf(LocalDateTime.class);
+        assertThat(articleRow.get("modifiedDate")).isNotNull();
+        assertThat(articleRow.get("isBlind")).isEqualTo(false);
+    }
 //
 //    @Test
 //    @DisplayName("selectDatetime")


### PR DESCRIPTION
## 구현 내용

순수 JDBC로 경량 DB 유틸리티 `SimpleDb`를 구현했습니다.

---

## 구조

```
src/main/java/com/back/
├── Article.java
└── simpleDb/
    ├── SimpleDb.java  → 커넥션 관리 + 트랜잭션
    └── Sql.java       → SQL 빌더 + 실행
```

---

## 구현 기능

**커넥션 관리**
- `ThreadLocal<Connection>` 을 활용해 스레드마다 독립적인 커넥션 보장
- `simpleDb.close()` 호출 전까지 커넥션 유지

**SQL 빌더**
- `append()` : SQL 조각 + 파라미터 체이닝 방식으로 조합
- `appendIn()` : IN절 `?` 를 동적으로 확장

**실행 메서드**
- `insert()` / `update()` / `delete()`
- `selectLong()` / `selectString()` / `selectBoolean()` / `selectDatetime()`
- `selectRow()` / `selectRows()`
- `selectRow(Class<T>)` / `selectRows(Class<T>)` : Jackson 기반 DTO 자동 매핑
- `selectLongs()`

**트랜잭션**
- `startTransaction()` / `commit()` / `rollback()`

---

## ✅ 테스트 결과

| 테스트 | 내용 | 결과 |
|--------|------|------|
| t001 | insert | ✅ |
| t002 | update | ✅ |
| t003 | delete | ✅ |
| t004 | selectRows | ✅ |
| t005 | selectRow | ✅ |
| t006 | selectDatetime | ✅ |
| t007 | selectLong | ✅ |
| t008 | selectString | ✅ |
| t009 | selectBoolean | ✅ |
| t010 | selectBoolean 2nd | ✅ |
| t011 | selectBoolean 3rd | ✅ |
| t012 | LIKE | ✅ |
| t013 | appendIn | ✅ |
| t014 | ORDER BY FIELD | ✅ |
| t015 | selectRows(Article) | ✅ |
| t016 | selectRow(Article) | ✅ |
| t017 | 멀티스레드 | ✅ |
| t018 | rollback | ✅ |
| t019 | commit | ✅ |

---

## 💡 어려웠던 점

**1. 패키지 충돌**
Spring의 `org.springframework.test.context.jdbc.Sql` 과 직접 만든 `com.back.simpleDb.Sql` 의 이름이 겹쳐 컴파일 에러가 발생했습니다. import 문을 명시적으로 교체해 해결했습니다.

**2. MySQL 9.x 인증 방식 변경**
MySQL 8.0부터 기본 인증 방식이 `caching_sha2_password` 로 변경되어 JDBC 연결이 끊기는 문제가 있었습니다. URL에 `allowPublicKeyRetrieval=true` 와 `useSSL=false` 옵션을 추가해 해결했습니다.

**3. ThreadLocal 설계**
처음에는 커넥션을 단순 필드로 관리하려 했으나, 멀티스레드 환경에서 커넥션이 공유되면 트랜잭션이 뒤섞이는 문제를 발견했습니다. `ThreadLocal<Connection>` 을 적용해 스레드마다 독립적인 커넥션을 보장했습니다.

**4. BIT(1) 타입 변환**
MySQL의 `BIT(1)` 컬럼이 JDBC를 통해 `byte[]` 로 넘어오는 것을 모르고 있었습니다. `convertValue()` 메서드에서 타입별 분기 처리로 해결했습니다.